### PR TITLE
fix(set): coverage for ProxySQL set_parser_algorithm=3 audit (P1..P6)

### DIFF
--- a/include/sql_parser/common.h
+++ b/include/sql_parser/common.h
@@ -59,6 +59,13 @@ inline int ci_cmp(const char* a, uint32_t alen, const char* b, uint8_t blen) {
 // -- Flags for NODE_SET_OPERATION --
 static constexpr uint16_t FLAG_SET_OP_ALL = 0x01;
 
+// -- Flags for NODE_IDENTIFIER / NODE_COLUMN_REF --
+// Set when the identifier was source-delimited (backtick `name` for MySQL,
+// double-quoted "name" for PostgreSQL). Allows downstream consumers to
+// distinguish PG's case-sensitive `"Name"` from case-insensitive `Name`,
+// which matters for SHOW search_path / SHOW <var> canonical re-emission.
+static constexpr uint16_t FLAG_IDENT_DELIMITED = 0x01;
+
 // -- Statement type (always set, even for PARTIAL/ERROR) --
 
 enum class StmtType : uint8_t {

--- a/include/sql_parser/expression_parser.h
+++ b/include/sql_parser/expression_parser.h
@@ -303,12 +303,32 @@ private:
             tok_.skip();  // consume dot
             Token col = tok_.next_token();
             AstNode* qname = make_node(arena_, NodeType::NODE_QUALIFIED_NAME);
-            qname->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, name_token.text));
-            qname->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, col.text));
+            AstNode* schema_node = make_node(arena_, NodeType::NODE_IDENTIFIER, name_token.text);
+            AstNode* col_node = make_node(arena_, NodeType::NODE_IDENTIFIER, col.text);
+            if (schema_node && token_was_delimited_(name_token))
+                schema_node->flags |= FLAG_IDENT_DELIMITED;
+            if (col_node && token_was_delimited_(col))
+                col_node->flags |= FLAG_IDENT_DELIMITED;
+            qname->add_child(schema_node);
+            qname->add_child(col_node);
             return qname;
         }
 
-        return make_node(arena_, NodeType::NODE_COLUMN_REF, name_token.text);
+        AstNode* col_ref = make_node(arena_, NodeType::NODE_COLUMN_REF, name_token.text);
+        if (col_ref && token_was_delimited_(name_token))
+            col_ref->flags |= FLAG_IDENT_DELIMITED;
+        return col_ref;
+    }
+
+    // True iff `t` is a TK_IDENTIFIER token whose source bytes were
+    // surrounded by backticks (MySQL) or double quotes (PostgreSQL).
+    // Uses lookback against the tokenizer's input buffer so the check is
+    // safe even when t.text starts at the very beginning of input.
+    bool token_was_delimited_(const Token& t) const {
+        if (t.type != TokenType::TK_IDENTIFIER) return false;
+        if (!t.text.ptr || t.text.ptr <= tok_.input_begin()) return false;
+        char prev = *(t.text.ptr - 1);
+        return prev == '`' || prev == '"';
     }
 
     // Infix precedence for a token type.

--- a/include/sql_parser/set_parser.h
+++ b/include/sql_parser/set_parser.h
@@ -8,6 +8,8 @@
 #include "sql_parser/arena.h"
 #include "sql_parser/expression_parser.h"
 
+#include <cstring>
+
 namespace sql_parser {
 
 template <Dialect D>
@@ -182,6 +184,36 @@ private:
     Arena& arena_;
     ExpressionParser<D> expr_parser_;
 
+    // Build "<prefix><name_content>" in the arena, dropping any
+    // backtick/double-quote delimiters that surrounded `name` in source.
+    // Used for assembling @@var / @var so the canonical AST name matches
+    // both `@@var` and ``@@`var``` forms.
+    StringRef build_scoped_identifier_(const char* prefix, const Token& name) {
+        size_t prefix_len = std::strlen(prefix);
+        size_t total = prefix_len + name.text.len;
+        char* buf = static_cast<char*>(arena_.allocate(total));
+        if (!buf) return StringRef{nullptr, 0};
+        std::memcpy(buf, prefix, prefix_len);
+        std::memcpy(buf + prefix_len, name.text.ptr, name.text.len);
+        return StringRef{buf, static_cast<uint32_t>(total)};
+    }
+
+    // Same as build_scoped_identifier_ but for the dotted form
+    // "<prefix><scope>.<name>" (e.g. @@session.sql_mode).
+    StringRef build_scoped_dotted_identifier_(const char* prefix,
+        const Token& scope, const Token& name) {
+        size_t prefix_len = std::strlen(prefix);
+        size_t total = prefix_len + scope.text.len + 1 + name.text.len;
+        char* buf = static_cast<char*>(arena_.allocate(total));
+        if (!buf) return StringRef{nullptr, 0};
+        size_t off = 0;
+        std::memcpy(buf + off, prefix, prefix_len); off += prefix_len;
+        std::memcpy(buf + off, scope.text.ptr, scope.text.len); off += scope.text.len;
+        buf[off++] = '.';
+        std::memcpy(buf + off, name.text.ptr, name.text.len); off += name.text.len;
+        return StringRef{buf, static_cast<uint32_t>(total)};
+    }
+
     AstNode* parse_comma_item() {
         Token peek = tok_.peek();
         if (peek.type == TokenType::TK_NAMES) {
@@ -294,26 +326,32 @@ private:
 
         Token var = tok_.peek();
         if (var.type == TokenType::TK_AT) {
-            // User variable @name
+            // User variable @name. The name may be backtick/double-quoted;
+            // in that case the source bytes between `@` and the name include
+            // the opening delimiter (and the closing delimiter sits one past
+            // name.text.len), so a naive StringRef-from-source produces
+            // `@name` -- missing the closing delimiter. Build the canonical
+            // `@name` form in the arena instead, dropping the delimiters.
             tok_.skip();
             Token name = tok_.next_token();
-            StringRef full{var.text.ptr,
-                static_cast<uint32_t>((name.text.ptr + name.text.len) - var.text.ptr)};
-            target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, full));
+            target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                build_scoped_identifier_("@", name)));
         } else if (var.type == TokenType::TK_DOUBLE_AT) {
-            // System variable @@[scope.]name
+            // System variable @@[scope.]name -- same delimiter handling
+            // concern as the @name branch above. Allocate `@@name` (or
+            // `@@scope.name`) in the arena to drop any backtick/double-quote
+            // delimiters from the canonical form.
             tok_.skip();
             Token name = tok_.next_token();
-            StringRef full{var.text.ptr,
-                static_cast<uint32_t>((name.text.ptr + name.text.len) - var.text.ptr)};
-            // Check for @@scope.name
             if (tok_.peek().type == TokenType::TK_DOT) {
                 tok_.skip();
                 Token actual_name = tok_.next_token();
-                full = StringRef{var.text.ptr,
-                    static_cast<uint32_t>((actual_name.text.ptr + actual_name.text.len) - var.text.ptr)};
+                target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                    build_scoped_dotted_identifier_("@@", name, actual_name)));
+            } else {
+                target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                    build_scoped_identifier_("@@", name)));
             }
-            target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, full));
         } else {
             // Plain variable name
             Token name = tok_.next_token();

--- a/include/sql_parser/set_parser.h
+++ b/include/sql_parser/set_parser.h
@@ -113,6 +113,51 @@ public:
             }
         }
 
+        // PostgreSQL: SET SCHEMA 'name' / SET SCHEMA name
+        // Per PG docs this is a shorthand for SET search_path TO name. Emit
+        // the canonical SET search_path form so downstream consumers see a
+        // tracked-variable assignment instead of a literal "SCHEMA" target.
+        if constexpr (D == Dialect::PostgreSQL) {
+            if (next.type == TokenType::TK_SCHEMA) {
+                tok_.skip();
+                AstNode* assignment = make_node(arena_, NodeType::NODE_VAR_ASSIGNMENT);
+                AstNode* target = make_node(arena_, NodeType::NODE_VAR_TARGET);
+                if (!assignment || !target) return nullptr;
+                target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                    StringRef{"search_path", 11}));
+                assignment->add_child(target);
+                AstNode* rhs = expr_parser_.parse();
+                if (!rhs) return nullptr;
+                assignment->add_child(rhs);
+                root->add_child(assignment);
+                return root;
+            }
+        }
+
+        // PostgreSQL: SET SEED N
+        // Per PG docs this is a shorthand for SELECT setseed(N) -- it does
+        // not configure a GUC. Emit a regular VAR_ASSIGNMENT with the
+        // synthetic name "seed"; downstream consumers can decide to ignore
+        // it (no tracked state) or forward it to the backend verbatim.
+        // The previous behaviour parsed it as `VAR_TARGET[SEED]` which
+        // looks like a tracked-variable name and confused consumers.
+        if constexpr (D == Dialect::PostgreSQL) {
+            if (next.type == TokenType::TK_IDENTIFIER && next.text.equals_ci("SEED", 4)) {
+                tok_.skip();
+                AstNode* assignment = make_node(arena_, NodeType::NODE_VAR_ASSIGNMENT);
+                AstNode* target = make_node(arena_, NodeType::NODE_VAR_TARGET);
+                if (!assignment || !target) return nullptr;
+                target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                    StringRef{"seed", 4}));
+                assignment->add_child(target);
+                AstNode* rhs = expr_parser_.parse();
+                if (!rhs) return nullptr;
+                assignment->add_child(rhs);
+                root->add_child(assignment);
+                return root;
+            }
+        }
+
         // PostgreSQL: SET TIME ZONE <value>
         // Per the PG docs this is an alias for SET TimeZone = <value>. The
         // tokenizer has no dedicated TK_TIME / TK_ZONE keywords so the lookahead

--- a/include/sql_parser/tokenizer.h
+++ b/include/sql_parser/tokenizer.h
@@ -15,7 +15,14 @@ public:
         cursor_ = input;
         end_ = input + len;
         has_peeked_ = false;
+        has_error_ = false;
     }
+
+    // True iff the tokenizer has emitted at least one TK_ERROR token since
+    // the last reset(). Lets callers distinguish "couldn't build an AST"
+    // from "the input was syntactically invalid" and surface the latter
+    // as ParseResult::ERROR rather than PARTIAL.
+    bool has_error() const { return has_error_; }
 
     Token next_token() {
         if (has_peeked_) {
@@ -53,6 +60,7 @@ private:
     const char* end_ = nullptr;
     Token peeked_;
     bool has_peeked_ = false;
+    bool has_error_ = false;
 
     uint32_t offset() const {
         return static_cast<uint32_t>(cursor_ - start_);
@@ -130,6 +138,7 @@ private:
     }
 
     Token make_token(TokenType type, const char* start, uint32_t len) {
+        if (type == TokenType::TK_ERROR) has_error_ = true;
         return Token{type, StringRef{start, len},
                      static_cast<uint32_t>(start - start_)};
     }
@@ -314,6 +323,17 @@ private:
                         ++cursor_;
                     uint32_t len = static_cast<uint32_t>(cursor_ - start);
                     return make_token(TokenType::TK_DOLLAR_NUM, start, len);
+                }
+                // $<letter|underscore>... is NOT a valid PG token at this
+                // position -- it looks like a parameter placeholder but is
+                // syntactically invalid (placeholders must be numeric, e.g.
+                // $1). Emit TK_ERROR so the caller can fail cleanly with
+                // ParseResult::ERROR instead of returning PARTIAL with a
+                // null AST and confusing downstream consumers.
+                {
+                    const char* start = cursor_;
+                    ++cursor_;  // consume $ so error offset is precise
+                    return make_token(TokenType::TK_ERROR, start, 1);
                 }
             }
         }

--- a/include/sql_parser/tokenizer.h
+++ b/include/sql_parser/tokenizer.h
@@ -41,7 +41,10 @@ public:
         }
     }
 
-    // Expose end of input for remaining-input calculation
+    // Expose start/end of input for remaining-input calculation and for
+    // safe lookback (e.g. detecting whether an identifier token was source-
+    // delimited via a preceding backtick / double-quote byte).
+    const char* input_begin() const { return start_; }
     const char* input_end() const { return end_; }
 
 private:

--- a/src/sql_parser/parser.cpp
+++ b/src/sql_parser/parser.cpp
@@ -303,6 +303,17 @@ ParseResult Parser<D>::parse_set() {
         r.ast = ast;
     }
 
+    // If the parse failed to produce any assignment AND the tokenizer
+    // saw a TK_ERROR token (e.g. PG `$word` -- a malformed parameter
+    // placeholder), downgrade PARTIAL to ERROR so syntactically-invalid
+    // input is reported clearly. Don't downgrade when we have a valid
+    // AST: in that case any TK_ERROR likely came from trailing junk
+    // beyond the parsed SET (or a null sentinel byte at end-of-input),
+    // and the SET itself is well-formed.
+    if (r.status == ParseResult::PARTIAL && tokenizer_.has_error()) {
+        r.status = ParseResult::ERROR;
+    }
+
     scan_to_end(r);
     return r;
 }

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -826,3 +826,198 @@ TEST(MySQLSetBulk, LenientAcceptsUnusualSyntax) {
             << "SQL: " << tc.sql;
     }
 }
+
+// ============================================================================
+// Coverage for the ProxySQL set_parser_algorithm=3 audit (issues P1..P6).
+// ============================================================================
+
+// Helper: walk to first VAR_ASSIGNMENT's VAR_TARGET, then to its single
+// IDENTIFIER child (single-target case). Returns nullptr if shape differs.
+static const AstNode* first_target_identifier(const AstNode* set_stmt) {
+    if (!set_stmt || set_stmt->type != NodeType::NODE_SET_STMT) return nullptr;
+    const AstNode* va = set_stmt->first_child;
+    if (!va || va->type != NodeType::NODE_VAR_ASSIGNMENT) return nullptr;
+    const AstNode* vt = va->first_child;
+    if (!vt || vt->type != NodeType::NODE_VAR_TARGET) return nullptr;
+    const AstNode* id = vt->first_child;
+    if (!id || id->type != NodeType::NODE_IDENTIFIER) return nullptr;
+    return id;
+}
+
+// Helper: get the RHS value node of the first VAR_ASSIGNMENT.
+static const AstNode* first_value(const AstNode* set_stmt) {
+    if (!set_stmt || set_stmt->type != NodeType::NODE_SET_STMT) return nullptr;
+    const AstNode* va = set_stmt->first_child;
+    if (!va || va->type != NodeType::NODE_VAR_ASSIGNMENT) return nullptr;
+    const AstNode* vt = va->first_child;
+    if (!vt) return nullptr;
+    return vt->next_sibling;
+}
+
+// ----------------------------------------------------------------------------
+// P6: MySQL SET @@`var`, SET @`var`, SET @@`scope`.`var` -- keep full name,
+// canonical form drops the backticks (matching the plain `SET `var`` path
+// which already produced IDENTIFIER [var] with no delimiters).
+// ----------------------------------------------------------------------------
+TEST(MySQLSetP6, DoubleAtBacktickedNameKeepsFullText) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET @@`wait_timeout`=28801";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "@@wait_timeout");
+}
+
+TEST(MySQLSetP6, AtBacktickedNameKeepsFullText) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET @`my_var`=1";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "@my_var");
+}
+
+TEST(MySQLSetP6, DoubleAtScopedBacktickedNameKeepsFullText) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET @@`session`.`sql_mode`='TRADITIONAL'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "@@session.sql_mode");
+}
+
+TEST(MySQLSetP6, DoubleAtScopedMixedDelimitersKeepsFullText) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET @@session.`sql_mode`='TRADITIONAL'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "@@session.sql_mode");
+}
+
+// ----------------------------------------------------------------------------
+// P3: PG SET SCHEMA name -- shorthand for SET search_path TO name.
+// ----------------------------------------------------------------------------
+TEST(PgSQLSetP3, SetSchemaQuotedString) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET SCHEMA 'public'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "search_path");
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_LITERAL_STRING);
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "public");
+}
+
+TEST(PgSQLSetP3, SetSchemaUnquoted) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET SCHEMA public";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "search_path");
+}
+
+// ----------------------------------------------------------------------------
+// P4: PG SET SEED N -- emit synthetic VAR_TARGET[seed] (lowercased), not
+// VAR_TARGET[SEED] which downstream consumers misclassify as an unknown GUC.
+// ----------------------------------------------------------------------------
+TEST(PgSQLSetP4, SetSeedFloat) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET SEED 0.5";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "seed");
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_LITERAL_FLOAT);
+}
+
+// ----------------------------------------------------------------------------
+// P1: FLAG_IDENT_DELIMITED set iff RHS identifier was source-delimited.
+// ----------------------------------------------------------------------------
+TEST(PgSQLSetP1, DoubleQuotedRhsIdentifierIsFlagged) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = \"public\"";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_COLUMN_REF);
+    EXPECT_TRUE(v->flags & FLAG_IDENT_DELIMITED) << "DELIMITED flag should be set";
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "public");
+}
+
+TEST(PgSQLSetP1, UnquotedRhsIdentifierIsNotFlagged) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = public";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_COLUMN_REF);
+    EXPECT_FALSE(v->flags & FLAG_IDENT_DELIMITED);
+}
+
+TEST(MySQLSetP1, BackticksOnRhsIdentifierAreFlagged) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET sql_mode = `STRICT_ALL_TABLES`";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_COLUMN_REF);
+    EXPECT_TRUE(v->flags & FLAG_IDENT_DELIMITED);
+}
+
+// ----------------------------------------------------------------------------
+// P2: bare PG $word in SET value position must be ERROR, not PARTIAL.
+// Quoted forms `'$user'` and `"$user"` remain valid.
+// ----------------------------------------------------------------------------
+TEST(PgSQLSetP2, BareDollarWordIsError) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = $user";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+TEST(PgSQLSetP2, SingleQuotedDollarUserStillOk) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = '$user'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_LITERAL_STRING);
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "$user");
+}
+
+TEST(PgSQLSetP2, DoubleQuotedDollarUserStillOkAndFlagged) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = \"$user\"";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_COLUMN_REF);
+    EXPECT_TRUE(v->flags & FLAG_IDENT_DELIMITED);
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "$user");
+}
+
+TEST(PgSQLSetP2, NumericPlaceholderStillOk) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SELECT * FROM t WHERE c = $1";
+    auto r = parser.parse(sql, strlen(sql));
+    // Not a SET, but make sure the tokenizer hasn't regressed $N placeholders.
+    EXPECT_NE(r.status, ParseResult::ERROR);
+}


### PR DESCRIPTION
## Summary

Six fixes in the SET-statement parser surfaced by an audit of the
ProxySQL `set_parser_algorithm=3` (ParserSQL-backed) path. The audit
was run against ProxySQL's TAP groups `pgsql-set_statement_test-t`,
`pgsql-set_parameter_validation_test-t`, `set_testing-t`, and
`test_filtered_set_statements-t`, which all rely on this code path.

Each commit is focused on one fix and is independently revertable.

## Fixes

| # | Commit | What | Why |
|---|---|---|---|
| **P6** | `3f055d9` | `SET @@\`var\`` / `SET @\`var\`` / `SET @@\`scope\`.\`var\`` keep the full identifier | Old code did `StringRef`-arithmetic from `@` to `name.text.ptr + name.text.len`, which is 1 byte short of the closing delimiter for backtick/double-quote tokens (those tokens cover only the inner content). The closing backtick was dropped. Fix: arena-allocate the canonical `@@name` form, matching the existing plain `SET \`var\`` -> `IDENTIFIER [var]` convention. |
| **P3** | `06bec75` | `SET SCHEMA name` (PG) emitted as `VAR_ASSIGNMENT(search_path, value)` | PG documents this as a shorthand for `SET search_path TO name`. The old AST `VAR_TARGET[SCHEMA] <value>` surfaces as an unknown GUC `schema` to consumers. |
| **P4** | `06bec75` | `SET SEED N` (PG) emitted as `VAR_ASSIGNMENT(seed, value)` (lowered) | Old AST `VAR_TARGET[SEED]` looked like an unknown variable. New form lets consumers ignore it as a non-GUC or forward verbatim. |
| **P1** | `e4f7f68` | `FLAG_IDENT_DELIMITED` (0x01) set on `NODE_IDENTIFIER` / `NODE_COLUMN_REF` when the source token was backtick or double-quote delimited | Previously `"public"` and bare `public` both produced `COLUMN_REF[public]`, indistinguishable. Required for PG's `SHOW search_path` canonical re-emission (case-sensitive `"Name"` vs. case-folded `Name`). Implementation: 1-byte lookback against the tokenizer input buffer, gated by a new `input_begin()` accessor. |
| **P2** | `9544541` | Bare PG `$word` -> `ParseResult::ERROR` (was `PARTIAL`) | PG `$` introduces `$N` placeholders or `$$...$$` strings. `$user`, `$_var`, etc. are invalid. Tokenizer now emits `TK_ERROR`; `Tokenizer::has_error()` sticks; `parse_set` downgrades `PARTIAL` -> `ERROR` only when no AST was produced (trailing junk past a valid AST doesn't taint the result). |
| tests | `12f1174` | 14 new GoogleTest cases in `tests/test_set.cpp` covering all of the above | Suite: 1223 -> 1237, all passing. |

## Backwards compatibility

* `TK_IDENTIFIER.text` is unchanged (still the inner content, no delimiters). Only `NODE_IDENTIFIER` / `NODE_COLUMN_REF` gain the new flag.
* `parse_set()` returns `ERROR` only when the parse failed AND the tokenizer emitted `TK_ERROR`. Previous valid-input behavior is preserved.
* `SET LOCAL var TO val` (PG) was reviewed but intentionally not changed -- the current `VAR_TARGET[LOCAL, var]` shape is already handled correctly by consumers that strip the `"LOCAL "` prefix.

## Test plan

- [x] `make test` -> 1237 passed, 0 failed (only the pre-existing 14 `SKIPPED` integration tests requiring external backends)
- [x] Hand-probed each affected SET form via a small AST-dumper harness; outputs match expectations.

## Downstream

ProxySQL will bump `deps/parsersql` to consume this once tagged as 1.0.4. The ProxySQL-side walker will then use `FLAG_IDENT_DELIMITED` for canonical search_path emission and recognize `seed` as a passthrough (separate PR against `sysown/proxysql v3.0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL `SET SCHEMA` and `SET SEED` commands.
  * Enhanced identifier parsing to distinguish case-sensitive delimited identifiers from case-insensitive undelimited ones.

* **Bug Fixes**
  * Improved error detection and reporting for malformed SQL input.

* **Tests**
  * Added comprehensive test coverage for SET command parsing and identifier handling across MySQL and PostgreSQL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/ParserSQL/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->