### PR TITLE
fix(set): post-1.0.4 SET-form audit follow-ups (PG ROLE/AUTH/CONSTRAINTS/CHARACTERISTICS, schema-qualified GUCs, TIME ZONE INTERVAL, malformed-input ERROR)

### DIFF
--- a/include/sql_parser/common.h
+++ b/include/sql_parser/common.h
@@ -219,6 +219,18 @@ enum class NodeType : uint16_t {
     // Shared
     NODE_STMT_OPTIONS,         // LOW_PRIORITY, IGNORE, QUICK, DELAYED, etc.
     NODE_UPDATE_SET_ITEM,      // single col=expr pair (shared by INSERT SET and UPDATE SET)
+
+    // PG-specific non-GUC SET forms. Appended at the end of the enum to
+    // avoid renumbering existing values (some consumers use NodeType as an
+    // array index). These look syntactically like SET variable assignments
+    // but are semantically transaction/session control (not tracked GUC
+    // parameters). Emitted with their value(s) as children so consumers
+    // can either forward verbatim to the backend or apply form-specific
+    // handling, without misclassifying them as unknown GUCs named ROLE /
+    // SESSION / CONSTRAINTS.
+    NODE_SET_ROLE,                  // SET [LOCAL] ROLE <name>|NONE|DEFAULT
+    NODE_SET_SESSION_AUTHORIZATION, // SET SESSION AUTHORIZATION <name>|DEFAULT
+    NODE_SET_CONSTRAINTS,           // SET CONSTRAINTS {ALL|<name>[,...]} {DEFERRED|IMMEDIATE}
 };
 
 } // namespace sql_parser

--- a/include/sql_parser/set_parser.h
+++ b/include/sql_parser/set_parser.h
@@ -88,6 +88,46 @@ public:
                 if (!root->first_child) return nullptr;
                 return root;
             }
+            // PostgreSQL: SET SESSION AUTHORIZATION { 'name' | name | DEFAULT }
+            // -- role-switching command, NOT a GUC assignment. Emit a
+            // dedicated NODE_SET_SESSION_AUTHORIZATION node.
+            if constexpr (D == Dialect::PostgreSQL) {
+                if (next.type == TokenType::TK_SESSION) {
+                    Token after = tok_.peek();
+                    if (after.type == TokenType::TK_IDENTIFIER &&
+                        after.text.equals_ci("AUTHORIZATION", 13)) {
+                        tok_.skip();
+                        AstNode* node = make_node(arena_,
+                            NodeType::NODE_SET_SESSION_AUTHORIZATION);
+                        if (!node) return nullptr;
+                        AstNode* val = parse_session_role_value_();
+                        if (!val) return nullptr;
+                        node->add_child(val);
+                        root->add_child(node);
+                        return root;
+                    }
+                    // SET SESSION CHARACTERISTICS AS TRANSACTION ...
+                    // -- emit as NODE_SET_TRANSACTION with SESSION scope so
+                    // consumers handle it uniformly with plain SET SESSION
+                    // TRANSACTION.
+                    if (after.type == TokenType::TK_IDENTIFIER &&
+                        after.text.equals_ci("CHARACTERISTICS", 15)) {
+                        tok_.skip();
+                        if (tok_.peek().type == TokenType::TK_AS) {
+                            tok_.skip();
+                            if (tok_.peek().type == TokenType::TK_TRANSACTION) {
+                                tok_.skip();
+                                AstNode* txn_node =
+                                    parse_set_transaction(scope_tok.text);
+                                if (txn_node) root->add_child(txn_node);
+                                if (!root->first_child) return nullptr;
+                                return root;
+                            }
+                        }
+                        return nullptr;
+                    }
+                }
+            }
             // Not TRANSACTION — it's SET GLOBAL var = expr
             // Fall through to variable assignment with scope
             AstNode* assignment = parse_variable_assignment(&scope_tok);
@@ -102,13 +142,85 @@ public:
             return root;
         }
 
-        // PostgreSQL: SET LOCAL var = expr
+        // PostgreSQL: SET LOCAL ... -- the LOCAL scope applies to whatever
+        // form follows. SET LOCAL ROLE / SET LOCAL <var> = ... etc. We peek
+        // past LOCAL to dispatch correctly; the LOCAL token itself is fed
+        // into the parsed node as scope info so downstream consumers can
+        // preserve the LOCAL semantics.
         if constexpr (D == Dialect::PostgreSQL) {
             if (next.type == TokenType::TK_LOCAL) {
                 Token scope_tok = tok_.next_token();
+                Token after = tok_.peek();
+                // SET LOCAL ROLE ...
+                if (after.type == TokenType::TK_IDENTIFIER &&
+                    after.text.equals_ci("ROLE", 4)) {
+                    tok_.skip();
+                    AstNode* node = parse_pg_set_role_value_(/*local=*/true, scope_tok);
+                    if (node) root->add_child(node);
+                    if (!root->first_child) return nullptr;
+                    return root;
+                }
+                // SET LOCAL <var> = expr -- fall to generic path with scope
                 AstNode* assignment = parse_variable_assignment(&scope_tok);
                 if (assignment) root->add_child(assignment);
                 if (!root->first_child) return nullptr;
+                return root;
+            }
+        }
+
+        // PostgreSQL: SET ROLE { <name> | 'name' | NONE | DEFAULT }
+        // This is a role-switching command, not a GUC assignment. Emit as a
+        // distinct node so consumers can forward to the backend instead of
+        // misclassifying it as an unknown variable named "ROLE".
+        if constexpr (D == Dialect::PostgreSQL) {
+            if (next.type == TokenType::TK_IDENTIFIER &&
+                next.text.equals_ci("ROLE", 4)) {
+                tok_.skip();
+                AstNode* node = parse_pg_set_role_value_(/*local=*/false, Token{});
+                if (node) root->add_child(node);
+                if (!root->first_child) return nullptr;
+                return root;
+            }
+        }
+
+        // PostgreSQL: SET CONSTRAINTS { ALL | <name>[, <name>, ...] }
+        //   { DEFERRED | IMMEDIATE }
+        // Transaction-control command, not a GUC. The first child is the
+        // target list (IDENTIFIER[ALL] or one-or-more IDENTIFIERs), the
+        // last child is the mode (IDENTIFIER[DEFERRED|IMMEDIATE]).
+        if constexpr (D == Dialect::PostgreSQL) {
+            if (next.type == TokenType::TK_IDENTIFIER &&
+                next.text.equals_ci("CONSTRAINTS", 11)) {
+                tok_.skip();
+                AstNode* node = make_node(arena_, NodeType::NODE_SET_CONSTRAINTS);
+                if (!node) return nullptr;
+                Token first = tok_.peek();
+                if (first.type == TokenType::TK_ALL) {
+                    tok_.skip();
+                    node->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                        StringRef{"ALL", 3}));
+                } else {
+                    // name[, name, ...] -- read identifiers separated by commas
+                    while (true) {
+                        Token name = tok_.peek();
+                        if (name.type != TokenType::TK_IDENTIFIER) break;
+                        tok_.skip();
+                        node->add_child(make_node(arena_,
+                            NodeType::NODE_IDENTIFIER, name.text));
+                        if (tok_.peek().type != TokenType::TK_COMMA) break;
+                        tok_.skip();
+                    }
+                    if (!node->first_child) return nullptr;
+                }
+                Token mode = tok_.next_token();
+                if (mode.type != TokenType::TK_IDENTIFIER ||
+                    !(mode.text.equals_ci("DEFERRED", 8) ||
+                      mode.text.equals_ci("IMMEDIATE", 9))) {
+                    return nullptr;
+                }
+                node->add_child(make_node(arena_,
+                    NodeType::NODE_IDENTIFIER, mode.text));
+                root->add_child(node);
                 return root;
             }
         }
@@ -257,6 +369,45 @@ private:
         buf[off++] = '.';
         std::memcpy(buf + off, name.text.ptr, name.text.len); off += name.text.len;
         return StringRef{buf, static_cast<uint32_t>(total)};
+    }
+
+    // Parse the value part of SET ROLE / SET LOCAL ROLE and return a
+    // NODE_SET_ROLE node carrying:
+    //   - optional first child IDENTIFIER[LOCAL] when invoked with local=true
+    //   - value child: IDENTIFIER for NONE / DEFAULT / unquoted name, or
+    //     LITERAL_STRING for the single-quoted form
+    AstNode* parse_pg_set_role_value_(bool local, const Token& scope_tok) {
+        AstNode* node = make_node(arena_, NodeType::NODE_SET_ROLE);
+        if (!node) return nullptr;
+        if (local) {
+            node->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                scope_tok.text));
+        }
+        AstNode* val = parse_session_role_value_();
+        if (!val) return nullptr;
+        node->add_child(val);
+        return node;
+    }
+
+    // Parse the right-hand-side of a SET ROLE / SET SESSION AUTHORIZATION:
+    // accepts a quoted string literal, the keywords NONE / DEFAULT, or a
+    // bare identifier role name. Returns nullptr on syntactic mismatch.
+    AstNode* parse_session_role_value_() {
+        Token tok = tok_.peek();
+        if (tok.type == TokenType::TK_STRING) {
+            tok_.skip();
+            return make_node(arena_, NodeType::NODE_LITERAL_STRING, tok.text);
+        }
+        if (tok.type == TokenType::TK_DEFAULT) {
+            tok_.skip();
+            return make_node(arena_, NodeType::NODE_IDENTIFIER, tok.text);
+        }
+        if (tok.type == TokenType::TK_IDENTIFIER) {
+            tok_.skip();
+            // NONE / DEFAULT / <name> are all just identifiers here.
+            return make_node(arena_, NodeType::NODE_IDENTIFIER, tok.text);
+        }
+        return nullptr;
     }
 
     AstNode* parse_comma_item() {

--- a/include/sql_parser/set_parser.h
+++ b/include/sql_parser/set_parser.h
@@ -294,6 +294,28 @@ public:
                         rhs_tok.type == TokenType::TK_LOCAL) {
                         tok_.skip();
                         assignment->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, rhs_tok.text));
+                    } else if (rhs_tok.type == TokenType::TK_IDENTIFIER &&
+                               rhs_tok.text.equals_ci("INTERVAL", 8)) {
+                        // SET TIME ZONE INTERVAL '<value>' <UNIT> -- the
+                        // INTERVAL keyword + string + unit is a single
+                        // PG interval literal. ExpressionParser doesn't
+                        // model this so it would drop everything after
+                        // INTERVAL. Capture the source bytes spanning
+                        // the whole literal and emit a single
+                        // LITERAL_STRING value so consumers can
+                        // re-emit it intact.
+                        Token start = tok_.next_token();  // INTERVAL
+                        Token val = tok_.next_token();    // '1'
+                        Token unit = tok_.next_token();   // HOUR
+                        if (val.type != TokenType::TK_STRING ||
+                            unit.type != TokenType::TK_IDENTIFIER) {
+                            return nullptr;
+                        }
+                        const char* span_end = unit.text.ptr + unit.text.len;
+                        StringRef whole{start.text.ptr,
+                            static_cast<uint32_t>(span_end - start.text.ptr)};
+                        assignment->add_child(make_node(arena_,
+                            NodeType::NODE_LITERAL_STRING, whole));
                     } else {
                         AstNode* rhs = expr_parser_.parse();
                         if (!rhs) return nullptr;
@@ -549,9 +571,38 @@ private:
                     build_scoped_identifier_("@@", name)));
             }
         } else {
-            // Plain variable name
+            // Plain variable name. PostgreSQL also accepts schema-qualified
+            // GUC names like `pg_catalog.search_path` or `myapp.setting`
+            // (the standard way to set custom application parameters). Emit
+            // the combined `<schema>.<name>` as one identifier so downstream
+            // normalization sees a single canonical name.
             Token name = tok_.next_token();
-            target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, name.text));
+            // Validate the name token actually looks like an identifier --
+            // `SET = 1` / `SET ,` / `SET ;` would otherwise stuff `=` / `,`
+            // / `;` into the IDENTIFIER node and confuse downstream code.
+            // Empty / EOF input was already rejected by parse_set() before
+            // we got here.
+            if (name.type != TokenType::TK_IDENTIFIER) {
+                tok_.flag_error();
+                return nullptr;
+            }
+            if constexpr (D == Dialect::PostgreSQL) {
+                if (tok_.peek().type == TokenType::TK_DOT) {
+                    tok_.skip();
+                    Token rhs = tok_.next_token();
+                    if (rhs.type != TokenType::TK_IDENTIFIER) {
+                        tok_.flag_error();
+                        return nullptr;
+                    }
+                    target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER,
+                        build_scoped_dotted_identifier_("", name, rhs)));
+                } else {
+                    target->add_child(make_node(arena_,
+                        NodeType::NODE_IDENTIFIER, name.text));
+                }
+            } else {
+                target->add_child(make_node(arena_, NodeType::NODE_IDENTIFIER, name.text));
+            }
         }
 
         assignment->add_child(target);
@@ -566,11 +617,16 @@ private:
             }
         }
 
-        // Parse RHS expression
+        // Parse RHS expression. If the parser couldn't produce one --
+        // typically because the input is truncated (`SET x =`), starts
+        // with a separator (`SET x = ,foo`, `SET x = ;`), or otherwise
+        // malformed -- flag a parse error so the eventual ParseResult is
+        // ERROR rather than PARTIAL with a missing-RHS AST.
         AstNode* rhs = expr_parser_.parse();
         if (rhs) {
             assignment->add_child(rhs);
         } else {
+            tok_.flag_error();
             return nullptr;
         }
 

--- a/include/sql_parser/tokenizer.h
+++ b/include/sql_parser/tokenizer.h
@@ -24,6 +24,12 @@ public:
     // as ParseResult::ERROR rather than PARTIAL.
     bool has_error() const { return has_error_; }
 
+    // Hook for parser-level (non-tokenizer) errors -- when the parser
+    // detects clearly invalid input (e.g. `SET = X`, `SET x = ;`,
+    // `SET x = ,foo`) it can flag the error so the eventual ParseResult
+    // is ERROR rather than PARTIAL with a null AST.
+    void flag_error() { has_error_ = true; }
+
     Token next_token() {
         if (has_peeked_) {
             has_peeked_ = false;

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -792,12 +792,17 @@ TEST_F(PgSQLSetTest, SetDatestyleMultiValue) {
 // Invalid syntax should return PARTIAL, not OK (issue #36)
 // ============================================================================
 
-TEST(MySQLSetBulk, InvalidSyntaxReturnsPartial) {
+TEST(MySQLSetBulk, InvalidSyntaxReturnsError) {
+    // Updated from the prior PARTIAL expectation: parse_set() now
+    // distinguishes truncated / malformed input from genuine parse
+    // failures and surfaces the former as ParseResult::ERROR. This
+    // matches the semantics consumers actually want (lock_hostgroup
+    // or hard-fail on clearly-bad SQL).
     Parser<Dialect::MySQL> parser;
     struct { const char* sql; int expected_status; } cases[] = {
-        {"SET",                        (int)ParseResult::PARTIAL},
-        {"SET ;",                      (int)ParseResult::PARTIAL},
-        {"SET GLOBAL",                 (int)ParseResult::PARTIAL},
+        {"SET",                        (int)ParseResult::ERROR},
+        {"SET ;",                      (int)ParseResult::ERROR},
+        {"SET GLOBAL",                 (int)ParseResult::ERROR},
     };
     for (const auto& tc : cases) {
         auto r = parser.parse(tc.sql, strlen(tc.sql));

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -1026,3 +1026,196 @@ TEST(PgSQLSetP2, NumericPlaceholderStillOk) {
     // Not a SET, but make sure the tokenizer hasn't regressed $N placeholders.
     EXPECT_NE(r.status, ParseResult::ERROR);
 }
+
+// ============================================================================
+// Post-1.0.4 audit follow-ups: PG non-GUC SET forms and value-preservation.
+// ============================================================================
+
+// Helper for the new NODE_SET_ROLE / NODE_SET_SESSION_AUTHORIZATION /
+// NODE_SET_CONSTRAINTS top-level children of NODE_SET_STMT.
+static const AstNode* first_set_child(const AstNode* set_stmt) {
+    return (set_stmt && set_stmt->type == NodeType::NODE_SET_STMT)
+        ? set_stmt->first_child : nullptr;
+}
+
+// ---- SET ROLE / SET LOCAL ROLE ---------------------------------------------
+TEST(PgSQLSetRole, QuotedRole) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET ROLE 'admin'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_ROLE);
+    ASSERT_NE(c->first_child, nullptr);
+    EXPECT_EQ(c->first_child->type, NodeType::NODE_LITERAL_STRING);
+    EXPECT_EQ(std::string(c->first_child->value_ptr, c->first_child->value_len), "admin");
+}
+
+TEST(PgSQLSetRole, UnquotedRole) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET ROLE admin";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_ROLE);
+}
+
+TEST(PgSQLSetRole, RoleNoneIsAccepted) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET ROLE NONE";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_ROLE);
+    ASSERT_NE(c->first_child, nullptr);
+    EXPECT_EQ(std::string(c->first_child->value_ptr, c->first_child->value_len), "NONE");
+}
+
+TEST(PgSQLSetRole, LocalRoleCarriesScope) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET LOCAL ROLE 'admin'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_ROLE);
+    // First child is the LOCAL scope identifier, second is the value.
+    ASSERT_NE(c->first_child, nullptr);
+    EXPECT_EQ(c->first_child->type, NodeType::NODE_IDENTIFIER);
+    EXPECT_EQ(std::string(c->first_child->value_ptr, c->first_child->value_len), "LOCAL");
+    ASSERT_NE(c->first_child->next_sibling, nullptr);
+    EXPECT_EQ(c->first_child->next_sibling->type, NodeType::NODE_LITERAL_STRING);
+}
+
+// ---- SET SESSION AUTHORIZATION ---------------------------------------------
+TEST(PgSQLSetSessionAuth, QuotedName) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET SESSION AUTHORIZATION 'alice'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_SESSION_AUTHORIZATION);
+    ASSERT_NE(c->first_child, nullptr);
+    EXPECT_EQ(c->first_child->type, NodeType::NODE_LITERAL_STRING);
+    EXPECT_EQ(std::string(c->first_child->value_ptr, c->first_child->value_len), "alice");
+}
+
+TEST(PgSQLSetSessionAuth, DefaultIsAccepted) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET SESSION AUTHORIZATION DEFAULT";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_SESSION_AUTHORIZATION);
+}
+
+// ---- SET CONSTRAINTS -------------------------------------------------------
+TEST(PgSQLSetConstraints, AllDeferred) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET CONSTRAINTS ALL DEFERRED";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_CONSTRAINTS);
+    ASSERT_NE(c->first_child, nullptr);
+    EXPECT_EQ(std::string(c->first_child->value_ptr, c->first_child->value_len), "ALL");
+    ASSERT_NE(c->first_child->next_sibling, nullptr);
+    EXPECT_EQ(std::string(c->first_child->next_sibling->value_ptr,
+                          c->first_child->next_sibling->value_len), "DEFERRED");
+}
+
+TEST(PgSQLSetConstraints, NamedImmediate) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET CONSTRAINTS my_fk IMMEDIATE";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_CONSTRAINTS);
+}
+
+// ---- SET SESSION CHARACTERISTICS AS TRANSACTION ----------------------------
+TEST(PgSQLSetSessionCharacteristics, EmitsSetTransaction) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* c = first_set_child(r.ast);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->type, NodeType::NODE_SET_TRANSACTION);
+}
+
+// ---- Schema-qualified GUC name (PG) ----------------------------------------
+TEST(PgSQLSetSchemaQualified, PgCatalogSearchPath) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET pg_catalog.search_path TO public";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "pg_catalog.search_path");
+}
+
+TEST(PgSQLSetSchemaQualified, CustomNamespace) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET myapp.setting = 'value'";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* id = first_target_identifier(r.ast);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(std::string(id->value_ptr, id->value_len), "myapp.setting");
+}
+
+// ---- TIME ZONE INTERVAL literal preserved ----------------------------------
+TEST(PgSQLSetTimeZoneInterval, FullLiteralPreserved) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET TIME ZONE INTERVAL '1' HOUR";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, NodeType::NODE_LITERAL_STRING);
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "INTERVAL '1' HOUR");
+}
+
+// ---- Clearly-malformed SET surfaces ERROR ----------------------------------
+TEST(PgSQLSetErrors, EqualsSignAsTargetIsError) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET = 1";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+TEST(PgSQLSetErrors, EmptyRhsIsError) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET datestyle = ;";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+TEST(PgSQLSetErrors, TruncatedRhsIsError) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path TO";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+TEST(PgSQLSetErrors, LeadingCommaIsError) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = ,public";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+TEST(MySQLSetErrors, TruncatedRhsIsError) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET autocommit =";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}


### PR DESCRIPTION
## Summary

Follow-ups to [#39](https://github.com/ProxySQL/ParserSQL/pull/39)
(v1.0.4). After v1.0.4 shipped I ran an exhaustive sweep of SET
forms instead of stopping at the original audit, and surfaced a
further batch of issues that should land together so ProxySQL has a
single bump rather than two.

## Fixes

### PG non-GUC SET forms (new node types: NODE_SET_ROLE,
NODE_SET_SESSION_AUTHORIZATION, NODE_SET_CONSTRAINTS)

Previously these were either mis-classified as GUC variable
assignments or returned `PARTIAL`:

| Input | Before | After |
|---|---|---|
| `SET ROLE 'admin' \| name \| NONE \| DEFAULT` | `VAR_ASSIGNMENT(ROLE, ...)` (looks like an unknown GUC named `ROLE`) | `NODE_SET_ROLE` with the value as the sole child |
| `SET LOCAL ROLE 'admin'` | `VAR_ASSIGNMENT([LOCAL, ROLE], ...)` | `NODE_SET_ROLE` with `[IDENTIFIER(LOCAL), value]` children |
| `SET SESSION AUTHORIZATION 'alice' \| name \| DEFAULT` | `VAR_ASSIGNMENT([SESSION, AUTHORIZATION], ...)` | `NODE_SET_SESSION_AUTHORIZATION` with the value as the sole child |
| `SET CONSTRAINTS ALL DEFERRED \| IMMEDIATE` | `PARTIAL` (ALL keyword stumbled the parser) | `NODE_SET_CONSTRAINTS` |
| `SET CONSTRAINTS name1, name2 DEFERRED` | `VAR_ASSIGNMENT(CONSTRAINTS, name1)` (single-name only, mis-classified) | `NODE_SET_CONSTRAINTS` with all names + mode |
| `SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL X` | `PARTIAL` | `NODE_SET_TRANSACTION` (same shape as plain SET SESSION TRANSACTION) |

The three new `NodeType` values are appended at the **end** of the
enum so existing consumers that index arrays by `NodeType` don't
get renumbered (I made that mistake first and it segfaulted the
suite -- fixed before commit).

### Schema-qualified PG GUC names

`SET pg_catalog.search_path TO public` (and the documented
`myapp.foo = ...` custom-namespace form) previously returned
`PARTIAL`. `parse_variable_assignment` now collects `<schema>.<name>`
into a single canonical `IDENTIFIER` for PostgreSQL.

### `SET TIME ZONE INTERVAL '1' HOUR` value preserved

ExpressionParser doesn't model PG interval literals, so the
`SET TIME ZONE` handler used to keep only `IDENTIFIER[INTERVAL]` and
silently drop the actual value + unit. The handler now special-cases
the three-token `INTERVAL '<value>' <UNIT>` form and emits the full
source span as a `LITERAL_STRING`.

### `ParseResult::ERROR` (not `PARTIAL`) for clearly-malformed SET

```
SET = 1                  -- target is `=`, not an identifier
SET x = ;                -- empty RHS
SET x =                  -- truncated RHS
SET x = ,foo             -- leading comma in PG list
SET search_path TO       -- truncated
SET                      -- bare SET
SET GLOBAL               -- truncated scope
```

All previously returned `PARTIAL` with a null AST -- indistinguishable
from "parser doesn't support this feature yet". `parse_variable_
assignment` now validates that the target token is `TK_IDENTIFIER`
and that ExpressionParser produced an RHS; on failure it calls
`tokenizer_.flag_error()` and `parse_set()` downgrades `PARTIAL` ->
`ERROR` via the same `has_error_` path already used for PG `$word`
in #39.

The pre-existing `InvalidSyntaxReturnsPartial` test (which codified
the old behavior) is renamed to `InvalidSyntaxReturnsError`.

## Test plan

- [x] `make test` -> **1254 passed**, 0 failed (1237 before, 17 new TESTs).
- [x] Hand-probed every form via an AST-dumper harness.

## Downstream

Tag as **v1.0.5** after merge. ProxySQL's `deps/parsersql` bump
(currently targeting 1.0.4 on `v3.0-260523`) will be updated to
1.0.5 in the same proxysql commit.