### PR TITLE
fix(parse): PARTIAL -> ERROR only when no assignment parsed (v1.0.6)

### DIFF
--- a/src/sql_parser/parser.cpp
+++ b/src/sql_parser/parser.cpp
@@ -303,14 +303,15 @@ ParseResult Parser<D>::parse_set() {
         r.ast = ast;
     }
 
-    // If the parse failed to produce any assignment AND the tokenizer
-    // saw a TK_ERROR token (e.g. PG `$word` -- a malformed parameter
-    // placeholder), downgrade PARTIAL to ERROR so syntactically-invalid
-    // input is reported clearly. Don't downgrade when we have a valid
-    // AST: in that case any TK_ERROR likely came from trailing junk
-    // beyond the parsed SET (or a null sentinel byte at end-of-input),
-    // and the SET itself is well-formed.
-    if (r.status == ParseResult::PARTIAL && tokenizer_.has_error()) {
+    // Downgrade PARTIAL -> ERROR only when the parse produced NO
+    // assignments at all AND the tokenizer flagged an error. This keeps
+    // ERROR clear for top-level malformed input (`SET = 1`,
+    // `SET datestyle = ;`, bare `$word`) while leaving multi-assignment
+    // SETs that contain one malformed element alongside well-formed
+    // ones at PARTIAL -- the well-formed assignments are still in the
+    // AST and the consumer can decide what to do with them.
+    if (r.status == ParseResult::PARTIAL && tokenizer_.has_error() &&
+        (!ast || !ast->first_child)) {
         r.status = ParseResult::ERROR;
     }
 


### PR DESCRIPTION
## Summary

Hot-fix for an over-aggressive PARTIAL -> ERROR downgrade introduced
in v1.0.5 ([#40](https://github.com/ProxySQL/ParserSQL/pull/40)) /
[#39](https://github.com/ProxySQL/ParserSQL/pull/39).

## The regression

v1.0.5's `parse_set()` downgraded `PARTIAL` to `ERROR` whenever
`tokenizer_.has_error()` was set. That was the right call for
top-level malformed input like `SET = 1` or `SET datestyle = ;`,
but too aggressive for multi-assignment SETs where one element is
malformed alongside well-formed ones:

```sql
SET sql_mode='TRADITIONAL', whatever = , autocommit=1
```

In v1.0.5: ERROR (the `whatever =` triggered `flag_error()`,
poisoning the whole AST even though `sql_mode` and `autocommit`
parsed cleanly into the children).

## The fix

Tighten the downgrade rule in `Parser<D>::parse_set()`: only promote
`PARTIAL` -> `ERROR` when the parse produced **no** children at all.
When the AST has at least one well-formed assignment, leave the
status at `PARTIAL` so consumers can still see and use the
successful elements.

The originally-targeted clearly-malformed cases are unaffected --
they all produce empty ASTs and still surface as `ERROR`:

* `SET = 1`
* `SET datestyle = ;`
* `SET autocommit =`
* `SET search_path = ,public`
* `SET search_path TO`
* `SET search_path = $user`
* bare `SET`, `SET GLOBAL`

## Test plan

- [x] `make test` -> **1254 passed** (no regression; existing P2 tests
      already cover the empty-AST ERROR cases).
- [x] Verified against ProxySQL's `setparser_parsersql_test`
      adapter test, which exercises multi-assignment inputs and was
      what caught this in the downstream proxysql build.

## Downstream

Tag as **v1.0.6** after merge. ProxySQL's `deps/parsersql` bump
will be updated from 1.0.5 to 1.0.6 in the same proxysql commit
(v1.0.5 was just tagged ~10 minutes ago and hasn't been consumed
by anything yet, so there's no in-flight breakage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined SET statement parsing error handling to more accurately distinguish between valid partial results and actual parsing failures. The parser now only reports errors when tokenization fails **and** no valid assignments are produced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/ParserSQL/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->