### PR TITLE
fix(parse): PARTIAL -> ERROR only when no assignment parsed (v1.0.6)

### DIFF
--- a/src/sql_parser/parser.cpp
+++ b/src/sql_parser/parser.cpp
@@ -303,14 +303,15 @@ ParseResult Parser<D>::parse_set() {
         r.ast = ast;
     }
 
-    // If the parse failed to produce any assignment AND the tokenizer
-    // saw a TK_ERROR token (e.g. PG `$word` -- a malformed parameter
-    // placeholder), downgrade PARTIAL to ERROR so syntactically-invalid
-    // input is reported clearly. Don't downgrade when we have a valid
-    // AST: in that case any TK_ERROR likely came from trailing junk
-    // beyond the parsed SET (or a null sentinel byte at end-of-input),
-    // and the SET itself is well-formed.
-    if (r.status == ParseResult::PARTIAL && tokenizer_.has_error()) {
+    // Downgrade PARTIAL -> ERROR only when the parse produced NO
+    // assignments at all AND the tokenizer flagged an error. Keeps
+    // ERROR clear for top-level malformed input (`SET = 1`,
+    // `SET datestyle = ;`, bare `$word`) while leaving multi-assignment
+    // SETs that contain one malformed element alongside well-formed
+    // ones at PARTIAL -- the well-formed assignments are still in the
+    // AST and the consumer can decide what to do with them.
+    if (r.status == ParseResult::PARTIAL && tokenizer_.has_error() &&
+        (!ast || !ast->first_child)) {
         r.status = ParseResult::ERROR;
     }
 


### PR DESCRIPTION
## Summary

Hot-fix for an over-aggressive PARTIAL -> ERROR downgrade introduced
in v1.0.5 ([#40](https://github.com/ProxySQL/ParserSQL/pull/40)).

## The regression

v1.0.5's \`parse_set()\` downgraded \`PARTIAL\` to \`ERROR\` whenever
\`tokenizer_.has_error()\` was set. That was the right call for
top-level malformed input (\`SET = 1\`, \`SET datestyle = ;\`, bare
\`\$word\`), but too aggressive for multi-assignment SETs where one
element is malformed alongside well-formed ones:

\`\`\`sql
SET sql_mode='TRADITIONAL', whatever = , autocommit=1
\`\`\`

v1.0.5: \`ERROR\` (the \`whatever =\` triggered \`flag_error()\`,
poisoning the whole AST even though \`sql_mode\` and \`autocommit\`
parsed cleanly into the children).

## The fix

Tighten the downgrade rule in \`Parser<D>::parse_set()\`: only promote
\`PARTIAL\` -> \`ERROR\` when the parse produced **no** children at all.

The originally-targeted clearly-malformed cases still surface as
\`ERROR\` (all of them produce empty ASTs):
\`SET = 1\`, \`SET datestyle = ;\`, \`SET autocommit =\`,
\`SET search_path = ,public\`, \`SET search_path TO\`,
\`SET search_path = \$user\`, bare \`SET\`, \`SET GLOBAL\`.

## Validation gate

Per the lesson from PR #39 / #40 -> v1.0.5: this fix was validated
end-to-end through ProxySQL's actual consumer (\`setparser_parsersql_test\`)
**before** being committed here.

- [x] ParserSQL \`make test\`: 1254/1254 passing
- [x] ProxySQL \`setparser_parsersql_test-t\` (built against this fix):
      **270/270 passing**, was 10 failing on v1.0.5
- [x] ProxySQL \`setparser_test-t\`, \`setparser_test2-t\`,
      \`setparser_test3-t\` (regex-parser variants, share the same
      fixture file): all still passing (1 + 226 + 224)

## Downstream

Tag as **v1.0.6** after merge. ProxySQL's \`deps/parsersql\` bump
will be updated to 1.0.6 in the same proxysql commit (v1.0.5 was
tagged but never consumed downstream, so there's no in-flight
breakage).