### PR TITLE
fix(tokenizer): allow `$` as PG identifier continuation char

### DIFF
--- a/include/sql_parser/tokenizer.h
+++ b/include/sql_parser/tokenizer.h
@@ -153,8 +153,17 @@ private:
         const char* start = cursor_;
         while (cursor_ < end_) {
             char c = *cursor_;
-            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-                (c >= '0' && c <= '9') || c == '_') {
+            bool is_cont = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                           (c >= '0' && c <= '9') || c == '_';
+            // PostgreSQL allows `$` as an identifier continuation char (but
+            // not as the first char, which is enforced because $ at start
+            // is handled by the $$ / $N branches in next_token_impl()).
+            // e.g. `SET search_path = schema$1` — `schema$1` is a single
+            // identifier, not `schema` followed by the placeholder `$1`.
+            if (!is_cont && D == Dialect::PostgreSQL && c == '$' && cursor_ > start) {
+                is_cont = true;
+            }
+            if (is_cont) {
                 ++cursor_;
             } else {
                 break;

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -1027,6 +1027,54 @@ TEST(PgSQLSetP2, NumericPlaceholderStillOk) {
     EXPECT_NE(r.status, ParseResult::ERROR);
 }
 
+// PostgreSQL identifiers can contain $ after the first character (per
+// https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS).
+// Earlier versions of the tokenizer stopped at $, so `schema$1` parsed as
+// the identifier `schema` followed by the placeholder `$1`, which was then
+// truncated/rejected downstream.
+TEST(PgSQLSetP2, DollarInUnquotedIdentIsContinuation) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = schema$1";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "schema$1");
+}
+
+TEST(PgSQLSetP2, DollarInMiddleOfIdent) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = my$schema$2_name";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+    const AstNode* v = first_value(r.ast);
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(std::string(v->value_ptr, v->value_len), "my$schema$2_name");
+}
+
+TEST(PgSQLSetP2, DollarAtStartStillEmitsError) {
+    // `$word` (dollar followed by non-digit) is reserved and must still
+    // emit TK_ERROR. Only mid-identifier `$` becomes a continuation char.
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = $bareword";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+// MySQL still disallows $ in unquoted identifiers — the PG-only continuation
+// rule must not leak into MySQL parsing.
+TEST(MySQLSet, DollarStillBreaksUnquotedIdent) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET schema$1 = 1";
+    auto r = parser.parse(sql, strlen(sql));
+    // MySQL: $ stops the identifier so the parse fails (or produces a partial
+    // result without `schema$1` as a single token).
+    const AstNode* v = first_value(r.ast);
+    if (v != nullptr) {
+        EXPECT_NE(std::string(v->value_ptr, v->value_len), "schema$1");
+    }
+}
+
 // ============================================================================
 // Post-1.0.4 audit follow-ups: PG non-GUC SET forms and value-preservation.
 // ============================================================================


### PR DESCRIPTION
## Summary

- Tokenizer now allows `$` as an identifier continuation char in PostgreSQL mode (per PG lexical-syntax docs).
- First-character constraint preserved: `$<letter>` at token start still emits `TK_ERROR`.
- MySQL behaviour unchanged.

## Why

ProxySQL's `set_parser_algorithm=3` path was breaking on inputs like `SET search_path = schema$1` — the walker only saw `schema` and the trailing `$1` fell through as a placeholder, producing `pgsql-set_parameter_validation_test-t` failures. The PG spec explicitly allows `$` in unquoted identifiers after the first character.

## Test plan

- [x] 4 new tests in `tests/test_set.cpp` covering: PG mid-ident `$`, multi-`$` idents, PG `$<word>` still erroring, MySQL behaviour unchanged
- [x] `make test` — 1258 tests pass, 0 fail
- [x] End-to-end validated in ProxySQL: spliced libsqlparser.a into deps and ran `setparser_parsersql_test-t` — strict byte-exact tests for `SET search_path = schema$1` and `SET search_path = my$schema$2_name` both pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PostgreSQL identifiers can now contain `$` characters (after the first character), e.g., `schema$1` is recognized as a single identifier.

* **Tests**
  * Added regression tests for PostgreSQL identifier parsing and MySQL compatibility verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ProxySQL/ParserSQL/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->