### PR TITLE
fix(tokenizer): unclosed delimited identifier emits TK_ERROR

### DIFF
--- a/include/sql_parser/tokenizer.h
+++ b/include/sql_parser/tokenizer.h
@@ -225,22 +225,39 @@ private:
     }
 
     // MySQL: backtick-quoted identifier
+    // Unclosed backticks emit TK_ERROR so the parser can fail cleanly with
+    // ParseResult::ERROR -- otherwise the tokenizer would silently swallow
+    // the rest of the input as one giant identifier (e.g. `SET x = `foo`
+    // would become identifier `foo` followed by an unclosed-backtick scan
+    // that consumes everything to EOF as another identifier).
     Token scan_backtick_identifier() {
+        const char* open_pos = cursor_;
         ++cursor_;  // skip opening backtick
         const char* content_start = cursor_;
         while (cursor_ < end_ && *cursor_ != '`') ++cursor_;
+        if (cursor_ >= end_) {
+            return make_token(TokenType::TK_ERROR, open_pos, 1);
+        }
         uint32_t len = static_cast<uint32_t>(cursor_ - content_start);
-        if (cursor_ < end_) ++cursor_;  // skip closing backtick
+        ++cursor_;  // skip closing backtick
         return make_token(TokenType::TK_IDENTIFIER, content_start, len);
     }
 
     // PostgreSQL: double-quoted identifier
+    // Unclosed `"` emits TK_ERROR -- same rationale as scan_backtick_identifier
+    // above. `SET search_path = "unclosed_quote, public` would otherwise be
+    // treated as identifier `unclosed_quote, public` (commas, spaces and all),
+    // pass validation, and corrupt search_path with garbage.
     Token scan_double_quoted_identifier() {
+        const char* open_pos = cursor_;
         ++cursor_;  // skip opening quote
         const char* content_start = cursor_;
         while (cursor_ < end_ && *cursor_ != '"') ++cursor_;
+        if (cursor_ >= end_) {
+            return make_token(TokenType::TK_ERROR, open_pos, 1);
+        }
         uint32_t len = static_cast<uint32_t>(cursor_ - content_start);
-        if (cursor_ < end_) ++cursor_;  // skip closing quote
+        ++cursor_;  // skip closing quote
         return make_token(TokenType::TK_IDENTIFIER, content_start, len);
     }
 

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -1075,6 +1075,43 @@ TEST(MySQLSet, DollarStillBreaksUnquotedIdent) {
     }
 }
 
+// An unclosed double-quote delimited identifier must fail the parse, not
+// silently swallow the rest of the input as one identifier. Without this,
+// `SET search_path = "unclosed_quote, public` parses as identifier
+// `unclosed_quote, public` (commas, spaces and all), which then passes
+// downstream validation and corrupts the stored value.
+TEST(PgSQLSetUnclosedQuote, DoubleQuoteUnterminatedIsError) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = \"unclosed_quote, public";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+// Same protection for MySQL backtick-delimited identifiers: an unclosed
+// backtick must error, not consume to EOF.
+TEST(MySQLSetUnclosedQuote, BacktickUnterminatedIsError) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET `unclosed_ident = 1";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::ERROR);
+}
+
+// Properly-closed delimited identifiers must still parse OK -- regression
+// guard against making the new error path too aggressive.
+TEST(PgSQLSetUnclosedQuote, ClosedDoubleQuoteStillOk) {
+    Parser<Dialect::PostgreSQL> parser;
+    const char* sql = "SET search_path = \"public\"";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+}
+
+TEST(MySQLSetUnclosedQuote, ClosedBacktickStillOk) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SET `wait_timeout` = 1";
+    auto r = parser.parse(sql, strlen(sql));
+    EXPECT_EQ(r.status, ParseResult::OK);
+}
+
 // ============================================================================
 // Post-1.0.4 audit follow-ups: PG non-GUC SET forms and value-preservation.
 // ============================================================================


### PR DESCRIPTION
## Summary

- `scan_double_quoted_identifier` and `scan_backtick_identifier` now emit `TK_ERROR` when reaching EOF without a matching delimiter, instead of silently producing a `TK_IDENTIFIER` containing everything in between.
- Properly-closed delimited identifiers are unchanged.

## Why

`SET search_path = \"unclosed_quote, public` was previously parsed as identifier `unclosed_quote, public` (commas, spaces, and all). The ProxySQL search_path validator accepted it as a 2-element list and overwrote the stored value with garbage — even though PG itself would reject the SQL outright. The parser was hiding the syntax error.

## Test plan

- [x] 4 new tests in `tests/test_set.cpp`: unclosed `\"`, unclosed backtick, closed-delim PG, closed-delim MySQL
- [x] `make test` — 1262 tests pass
- [x] End-to-end verified in ProxySQL: spliced libsqlparser.a into deps and ran `setparser_parsersql_test-t`. Walker now returns empty map for `SET search_path = \"unclosed_quote, public` (was returning `unclosed_quote, public` as the value before)