### PR TITLE
build: make CXX overridable (CXX ?= g++) for clang builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX = g++
+CXX ?= g++
 CXXFLAGS = -std=c++17 -Wall -Wextra -g -O2
 CPPFLAGS = -I./include -I./third_party/googletest/googletest/include
 


### PR DESCRIPTION
## Summary
`Makefile` hardcoded `CXX = g++`. A `CXX=clang++ make` **environment** prefix does not override a Makefile `=` assignment, so downstream consumers that build ParserSQL with clang in containers shipping only clang/clang++ (no g++) failed with exit 127 (`g++: command not found`).

Changing to `CXX ?= g++` lets the environment-provided compiler win while keeping g++ as the default.

## Impact
Surfaced building ProxySQL 3.0.9/3.1.9 clang packages (16 distro variants failed). Cut as **v1.0.9** and re-vendored into ProxySQL.

## Test
`CXX=clang++ make lib` now compiles with clang++ (previously ignored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system configuration to respect externally-provided C++ compiler settings. The build process now supports custom compiler selection via environment variables and command-line parameters, enabling greater flexibility for developers and automated build systems. This enhancement improves compatibility across different development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->