### PR TITLE
fix: route sharded DML through ShardMap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,66 @@
-# Repository Guidelines
+# Agent notes
 
-## Project Structure & Module Organization
-Core parser headers live in `include/sql_parser/` and parser implementations in `src/sql_parser/`. SQL engine, remote execution, and transaction interfaces live in `include/sql_engine/` with implementations in `src/sql_engine/`. Tests are in `tests/`, mostly as focused `test_<area>.cpp` files plus `corpus_test.cpp` for large parser corpora. Developer tools live in `tools/`, automation scripts in `scripts/`, benchmark reports in `docs/benchmarks/`, and vendored dependencies in `third_party/`.
+Trust the `Makefile` over prose. Extension recipes live in `CLAUDE.md`. `docs/superpowers/` is historical, not current behavior.
 
-## Build, Test, and Development Commands
-Use the `Makefile` as the source of truth:
+## Layout
 
-- `make all` builds `libsqlparser.a` and runs the full GoogleTest suite.
-- `make test` rebuilds `run_tests` and executes all tests locally.
-- `make lib` builds just the static library.
-- `make build-sqlengine` builds the interactive CLI as `./sqlengine`.
-- `make build-corpus-test` builds `./corpus_test` for external SQL corpus validation.
-- `make bench` runs the benchmark binary; use it for parser or executor performance changes.
-- `make clean` removes generated objects and binaries.
+- Parser: header-only templates in `include/sql_parser/` except `src/sql_parser/{arena,parser}.cpp`
+- Engine: headers in `include/sql_engine/` (`operators/`, `functions/`, `rules/`); compiled files are the explicit `ENGINE_SRCS` list
+- High-level API: `Session<D>` (`include/sql_engine/session.h`) — parse → plan → optimize → distribute → execute
+- Production remote path: `ThreadSafeMultiRemoteExecutor`, not the single-connection executors
+- All shard routing (SELECT prune and DML) goes through `ShardMap`. Do not add a private hash in the planner.
+- Backend URL / shard-spec parsing: `tool_config_parser` — do not add another copy in tools
+- Do not edit `third_party/`
 
-## Coding Style & Naming Conventions
-This repository is C++17 with warnings enabled via `-Wall -Wextra`. Match the existing style: 4-space indentation, opening braces on the same line, and concise comments only where the code is not obvious. Use `PascalCase` for types, `snake_case` for functions and methods, `UPPER_SNAKE_CASE` for include guards and macros, and keep file names module-oriented such as `parser.cpp`, `distributed_txn.h`, and `test_select.cpp`. There is no repo-wide formatter config outside vendored code, so follow surrounding files closely.
+## Commands
 
-## Testing Guidelines
-Tests use GoogleTest through `tests/test_main.cpp`. Add coverage in the nearest existing `test_<feature>.cpp`, or create a new file with that pattern if the area is new. Prefer small, focused `TEST` or `TEST_F` cases that mirror the production module name. Run `make test` before opening a PR; for grammar or dialect work, also run `make build-corpus-test`.
+```bash
+make all                 # libsqlparser.a + full GoogleTest suite
+make lib
+make test                # rebuild ./run_tests and run it
+./run_tests --gtest_filter='*WindowFunc*'
+make build-sqlengine     # ./sqlengine
+make build-corpus-test   # ./corpus_test
+make mysql-server engine-stress bench-distributed
+make bench               # -O2; release+corpus report: bash scripts/run_benchmarks.sh report.md
+make test-pg-compat      # committed PG18 gate (needs PG_COMPAT_CACHE / libpg_query)
+```
 
-## Commit & Pull Request Guidelines
-Recent history uses short conventional prefixes such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`. Keep commit titles imperative and specific, for example `feat: add UTC normalization for PgSQL timestamps`. PRs should target `main`, explain parser/engine behavior changes, list the commands you ran, and link related issues. Include benchmark or corpus-test notes when performance or SQL coverage changes. Do not commit generated `.o` files, binaries, or benchmark artifacts.
+New `tests/test_*.cpp` must be appended to `TEST_SRCS`. New `src/sql_engine/*.cpp` must be appended to `ENGINE_SRCS`. Otherwise they never build.
+
+No repo formatter. C++17, `-Wall -Wextra`. Match neighboring files. Includes: `"sql_parser/..."`, `"sql_engine/..."`.
+
+macOS needs client libs: `brew install mysql-client postgresql zstd`, then
+`LIBRARY_PATH=/opt/homebrew/lib make all MYSQL_CFLAGS="-I/opt/homebrew/opt/mysql-client/include"`.
+Tests and tools link libmysqlclient + libpq even when no live backend is used.
+
+## Parser gotchas
+
+- Dialect is compile-time: `Parser<Dialect::MySQL>` / `Parser<Dialect::PostgreSQL>`. One `Parser` per thread (non-copyable).
+- `parse(sql, len)` takes an explicit length. `StringRef` views the input — keep the SQL buffer alive until you are done with the AST.
+- `parser.reset()` rewinds the arena; AST and emitter output are invalid after reset.
+- Keyword lookup is a hash table from `keywords_mysql.h` / `keywords_pgsql.h`. Keep those arrays alphabetically sorted. New keywords also need `token.h`, and usually `is_keyword_as_identifier()` in `expression_parser.h` plus `is_alias_start()` in `table_ref_parser.h`.
+- Classifier switch: `classify_and_dispatch()` in `src/sql_parser/parser.cpp`.
+- Status is `OK` / `PARTIAL` / `ERROR`. `PARTIAL` can still have a usable AST (e.g. multi-assign SET with one bad element). Do not treat PARTIAL as a hard failure without checking the AST.
+
+## Tests
+
+Default gate: `make test`. Add coverage in the nearest `tests/test_<area>.cpp`.
+
+Live-backend tests `GTEST_SKIP` when unreachable:
+- MySQL `127.0.0.1:13306` root/test/testdb — `scripts/start_test_backends.sh`
+- PostgreSQL `127.0.0.1:15432` postgres/test/testdb — same script
+- `test_single_backend_txn.cpp` / `test_distributed_txn.cpp` skip unless `MYSQL_TEST_HOST` is set
+
+`scripts/start_test_backends.sh` and `scripts/start_sharding_demo.sh` both bind **13306** — do not run them together.
+
+`make test-sqlengine` drives `./sqlengine` and **fails loudly** (exit 2) if containers are missing. Start them first:
+- in-memory: no backend
+- single: `scripts/setup_single_backend.sh` (port 13308)
+- sharded: `scripts/start_sharding_demo.sh` (13306 + 13307)
+
+Corpus is not in-tree. `./corpus_test <mysql|pgsql> [files...]`. Full download: `scripts/run_benchmarks.sh`. CI runs `make all` plus a corpus subset. For grammar/dialect work, also build `corpus_test`.
+
+## Commits / PRs
+
+Conventional prefixes (`feat:`, `fix:`, `test:`, `docs:`, `chore:`, `build:`). PRs target `main`. Do not commit `*.o`, `libsqlparser.a`, `run_tests`, `sqlengine`, `corpus_test`, `run_bench*`, or benchmark artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Trust the `Makefile` over prose. Extension recipes live in `CLAUDE.md`. `docs/su
 - Parser: header-only templates in `include/sql_parser/` except `src/sql_parser/{arena,parser}.cpp`
 - Engine: headers in `include/sql_engine/` (`operators/`, `functions/`, `rules/`); compiled files are the explicit `ENGINE_SRCS` list
 - High-level API: `Session<D>` (`include/sql_engine/session.h`) — parse → plan → optimize → distribute → execute
-- Production remote path: `ThreadSafeMultiRemoteExecutor`, not the single-connection executors
+- Production remote path: `ThreadSafeMultiRemoteExecutor` (pooled MySQL **and** PostgreSQL), not the single-connection executors
 - All shard routing (SELECT prune and DML) goes through `ShardMap`. Do not add a private hash in the planner.
 - Backend URL / shard-spec parsing: `tool_config_parser` — do not add another copy in tools
 - Do not edit `third_party/`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ echo "SELECT 1 + 2, UPPER('hello'), COALESCE(NULL, 42)" | ./sqlengine
 # Against a MySQL backend
 ./sqlengine --backend "mysql://root:pass@127.0.0.1:3306/mydb?name=primary"
 
-# Sharded across two backends
+# Sharded across two backends (2PC is on; optional --txn-log PATH)
 ./sqlengine \
   --backend "mysql://root:pass@host1:3306/db?name=shard1" \
   --backend "mysql://root:pass@host2:3306/db?name=shard2" \
@@ -171,20 +171,20 @@ ResultSet rs = executor.execute(plan);
 #include "sql_engine/session.h"
 #include "sql_engine/thread_safe_executor.h"
 #include "sql_engine/shard_map.h"
-#include "sql_engine/local_txn.h"
+#include "sql_engine/distributed_txn.h"
 
-// Backends (connection-pooled, thread-safe)
+// Backends (connection-pooled, thread-safe; MySQL or PostgreSQL)
 ThreadSafeMultiRemoteExecutor executor;
 executor.add_backend({.name = "shard1", .host = "h1", .port = 3306, ...});
 executor.add_backend({.name = "shard2", .host = "h2", .port = 3306, ...});
 
 // Sharding policy: "users" is sharded on "id" across shard1, shard2
 ShardMap shards;
-shards.add_sharded_table("users", "id", {"shard1", "shard2"});
+shards.add_table({"users", "id", {{"shard1"}, {"shard2"}}});
 
-// Catalog, transactions, session
+// Catalog + 2PC (required for atomic multi-shard DML)
 InMemoryCatalog catalog;  /* ... add_table(...) ... */
-LocalTransactionManager txn;
+DistributedTransactionManager txn(executor);
 Session<Dialect::MySQL> session(catalog, txn);
 session.set_remote_executor(&executor);
 session.set_shard_map(&shards);
@@ -354,11 +354,11 @@ auto report = recovery.recover();
 
 ### Distributed execution
 
-- **Shard routing** — shard-key lookups go to one backend; scatter queries go to all
-- **Distributed aggregation** — per-shard partial aggregates + coordinator merge (COUNT+SUM+MIN+MAX + AVG from SUM/COUNT)
-- **Distributed sort** — per-shard sort + coordinator merge
-- **Cross-shard joins** — hash-join coordinator; materialized subquery cache
-- **Cross-shard DML** — scatter INSERT/UPDATE/DELETE when no shard key; single-shard when key present
+- **Shard routing** — equality / `IN` / `OR` of equalities prune via `ShardMap`; RANGE also prunes `<`/`>`/`BETWEEN`. Placeholders scatter.
+- **Distributed aggregation** — per-shard partial aggregates + coordinator merge (`COUNT`/`SUM`/`MIN`/`MAX`/`AVG`). `COUNT(DISTINCT)` gathers then aggregates locally.
+- **Distributed sort** — per-shard sort + coordinator merge when keys are table columns
+- **Joins** — co-located same-key joins push down; otherwise gather both sides and join locally
+- **Cross-shard DML** — routed by `ShardMap`; missing/non-literal shard key and multi-table DML on shards fail closed
 - **Cross-shard INSERT ... SELECT** — source materialized, rows routed by destination shard key
 
 ### Transactions
@@ -372,10 +372,10 @@ auto report = recovery.recover();
 
 ### Backends & connectivity
 
-- **MySQL** — libmysqlclient with pooled and single-connection paths, UTF-8, configurable timeouts
-- **PostgreSQL** — libpq with statement_timeout, UTC-normalized TIMESTAMPTZ handling
+- **MySQL** — libmysqlclient with pooled (`ThreadSafeMultiRemoteExecutor`) and single-connection paths
+- **PostgreSQL** — libpq pooled on the same executor, plus a single-connection path; `statement_timeout` and UTC TIMESTAMPTZ
 - **SSL/TLS** — `ssl_mode`, `ssl_ca`, `ssl_cert`, `ssl_key` configurable per backend for both dialects
-- **Connection pool** — thread-safe with health checks, reconnection, RAII `ConnectionGuard`
+- **Connection pool** — thread-safe per dialect, RAII checkout, poison-on-error
 - **MySQL wire-protocol server** — `mysql_server` speaks the MySQL protocol; backends are ParserSQL engines
 
 ### Thread-safety
@@ -388,7 +388,7 @@ auto report = recovery.recover();
 
 | Tool | Build | Purpose |
 |---|---|---|
-| `sqlengine` | `make build-sqlengine` | Interactive SQL CLI; stdin, one-shot, or REPL; optional backends and sharding |
+| `sqlengine` | `make build-sqlengine` | Interactive SQL CLI; 2PC when `--backend` is set; optional `--txn-log` |
 | `mysql_server` | `make mysql-server` | MySQL wire-protocol server fronted by the ParserSQL engine |
 | `corpus_test` | `make build-corpus-test` | Read SQL from stdin/files, parse each, report OK/PARTIAL/ERROR |
 | `engine_stress_test` | `make engine-stress` | Direct-API engine stress test |

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -357,7 +357,13 @@ private:
         if (keys.empty()) return all_shards;
 
         std::vector<size_t> target_indices;
-        if (keys.size() > 1) {
+        if (keys.size() > 1 &&
+            shards_.routing_strategy(table->table_name) == RoutingStrategy::RANGE) {
+            sql_parser::StringRef first{keys[0].c_str(),
+                static_cast<uint32_t>(keys[0].size())};
+            extract_shard_targets(where_expr, first, table->table_name,
+                                  all_shards.size(), target_indices);
+        } else if (keys.size() > 1) {
             extract_composite_targets(where_expr, keys, table->table_name, target_indices);
         } else {
             sql_parser::StringRef shard_key{keys[0].c_str(),
@@ -1203,6 +1209,157 @@ private:
         return current ? current : join_node;
     }
 
+    bool column_on_table(const sql_parser::AstNode* node, const TableInfo* table,
+                         const TableInfo* other) const {
+        if (!node || !table) return false;
+        if (node->type == sql_parser::NodeType::NODE_QUALIFIED_NAME) {
+            const sql_parser::AstNode* t = node->first_child;
+            if (!t) return false;
+            sql_parser::StringRef tn = t->value();
+            if (table->table_name.equals_ci(tn.ptr, tn.len)) return true;
+            if (table->alias.ptr && table->alias.equals_ci(tn.ptr, tn.len)) return true;
+            return false;
+        }
+        if (node->type == sql_parser::NodeType::NODE_COLUMN_REF ||
+            node->type == sql_parser::NodeType::NODE_IDENTIFIER) {
+            if (!catalog_.get_column(table, node->value())) return false;
+            if (other && catalog_.get_column(other, node->value())) return false;
+            return true;
+        }
+        return false;
+    }
+
+    const sql_parser::AstNode* probe_key_in_join(const sql_parser::AstNode* cond,
+                                                 const TableInfo* probe,
+                                                 const TableInfo* build) const {
+        if (!cond || !probe || !build) return nullptr;
+        const auto& keys = shards_.get_shard_keys(probe->table_name);
+        if (keys.size() != 1) return nullptr;
+        sql_parser::StringRef sk{keys[0].c_str(), static_cast<uint32_t>(keys[0].size())};
+        std::vector<std::pair<const sql_parser::AstNode*, const sql_parser::AstNode*>> eqs;
+        collect_eq_pairs(cond, eqs);
+        for (const auto& eq : eqs) {
+            if (is_shard_key_ref(eq.first, sk) && column_on_table(eq.second, build, probe))
+                return eq.first;
+            if (is_shard_key_ref(eq.second, sk) && column_on_table(eq.first, build, probe))
+                return eq.second;
+        }
+        return nullptr;
+    }
+
+    sql_parser::AstNode* make_in_list_on_column(const sql_parser::AstNode* col,
+                                                const std::vector<Value>& values) {
+        if (!col || values.empty()) return nullptr;
+        sql_parser::AstNode* stub = sql_parser::make_node(
+            arena_, sql_parser::NodeType::NODE_IN_LIST,
+            sql_parser::StringRef{nullptr, 0});
+        sql_parser::AstNode* col_copy = sql_parser::make_node(
+            arena_, col->type, col->value(), col->flags);
+        col_copy->first_child = col->first_child;
+        stub->add_child(col_copy);
+        return build_in_list_from_values(stub, values);
+    }
+
+    sql_parser::AstNode* and_preds(const sql_parser::AstNode* a,
+                                   const sql_parser::AstNode* b) {
+        if (!a) return const_cast<sql_parser::AstNode*>(b);
+        if (!b) return const_cast<sql_parser::AstNode*>(a);
+        sql_parser::AstNode* n = sql_parser::make_node(
+            arena_, sql_parser::NodeType::NODE_BINARY_OP,
+            sql_parser::StringRef{"AND", 3});
+        n->add_child(const_cast<sql_parser::AstNode*>(a));
+        n->add_child(const_cast<sql_parser::AstNode*>(b));
+        return n;
+    }
+
+    std::vector<Value> collect_build_join_keys(const TableInfo* build,
+                                               const sql_parser::AstNode* where_expr,
+                                               const sql_parser::AstNode* join_eq_other) {
+        std::vector<Value> out;
+        if (!build || !join_eq_other || !remote_executor_) return out;
+        const sql_parser::AstNode* proj[1] = {join_eq_other};
+        const auto& shards = shards_.get_shards(build->table_name);
+        if (shards.empty()) return out;
+        std::vector<ShardInfo> targets = shards;
+        if (shards_.is_sharded(build->table_name) && shards.size() > 1)
+            return out;
+        sql_parser::StringRef sql = qb_.build_select(
+            build, where_expr, proj, 1, nullptr, 0,
+            nullptr, nullptr, 0, -1, true);
+        ResultSet rs = remote_executor_->execute(shards[0].backend_name.c_str(), sql);
+        for (const auto& row : rs.rows) {
+            if (row.column_count > 0 && value_is_routable(row.get(0)))
+                out.push_back(copy_value_arena(row.get(0)));
+        }
+        return out;
+    }
+
+    const sql_parser::AstNode* other_eq_side(const sql_parser::AstNode* cond,
+                                             const sql_parser::AstNode* probe_key) const {
+        std::vector<std::pair<const sql_parser::AstNode*, const sql_parser::AstNode*>> eqs;
+        collect_eq_pairs(cond, eqs);
+        for (const auto& eq : eqs) {
+            if (eq.first == probe_key) return eq.second;
+            if (eq.second == probe_key) return eq.first;
+        }
+        return nullptr;
+    }
+
+    PlanNode* try_semijoin_prune(PlanNode* join_node,
+                                 const TableInfo* left_table,
+                                 const TableInfo* right_table) {
+        if (!join_node || !remote_executor_ || !join_node->join.condition)
+            return nullptr;
+        if (!left_table || !right_table) return nullptr;
+
+        bool ls = shards_.is_sharded(left_table->table_name);
+        bool rs = shards_.is_sharded(right_table->table_name);
+        if (ls == rs) return nullptr;
+
+        const TableInfo* probe = ls ? left_table : right_table;
+        const TableInfo* build = ls ? right_table : left_table;
+        bool probe_is_left = ls;
+        const sql_parser::AstNode* probe_key =
+            probe_key_in_join(join_node->join.condition, probe, build);
+        if (!probe_key) return nullptr;
+        const sql_parser::AstNode* build_col =
+            other_eq_side(join_node->join.condition, probe_key);
+        if (!build_col) return nullptr;
+
+        ScanContext bctx = extract_scan_context(
+            probe_is_left ? join_node->right : join_node->left);
+        std::vector<Value> keys = collect_build_join_keys(build, bctx.where_expr, build_col);
+        if (keys.empty()) return nullptr;
+
+        sql_parser::AstNode* in_list = make_in_list_on_column(probe_key, keys);
+        if (!in_list) return nullptr;
+
+        ScanContext pctx = extract_scan_context(
+            probe_is_left ? join_node->left : join_node->right);
+        if (!pctx.scan) return nullptr;
+        const sql_parser::AstNode* probe_where = and_preds(pctx.where_expr, in_list);
+        PlanNode* probe_dist = distribute_scan(pctx.scan, probe_where,
+                                               nullptr, nullptr, nullptr, false);
+
+        PlanNode* build_dist = nullptr;
+        if (bctx.scan && !shards_.is_sharded(build->table_name)) {
+            sql_parser::StringRef sql = qb_.build_select(
+                build, bctx.where_expr, nullptr, 0, nullptr, 0,
+                nullptr, nullptr, 0, -1, false);
+            build_dist = make_remote_scan(
+                shards_.get_backend(build->table_name), sql, build);
+        } else {
+            build_dist = distribute_node(probe_is_left ? join_node->right : join_node->left);
+        }
+        if (!probe_dist || !build_dist) return nullptr;
+
+        PlanNode* result = make_plan_node(arena_, PlanNodeType::JOIN);
+        result->join = join_node->join;
+        result->left = probe_is_left ? probe_dist : build_dist;
+        result->right = probe_is_left ? build_dist : probe_dist;
+        return result;
+    }
+
     PlanNode* distribute_join(PlanNode* join_node) {
         const TableInfo* left_table = find_table(join_node->left);
         const TableInfo* right_table = find_table(join_node->right);
@@ -1216,6 +1373,9 @@ private:
                                        shards_.get_shard_keys(right_table->table_name))) {
             return distribute_colocated_join(join_node, left_table, right_table);
         }
+
+        if (PlanNode* sj = try_semijoin_prune(join_node, left_table, right_table))
+            return sj;
 
         PlanNode* left_dist = nullptr;
         PlanNode* right_dist = nullptr;

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -999,11 +999,71 @@ private:
         return result;
     }
 
-    // Case 5: Cross-backend join
+    bool join_on_shard_keys(const sql_parser::AstNode* cond,
+                            sql_parser::StringRef left_key,
+                            sql_parser::StringRef right_key) const {
+        if (!cond || cond->type != sql_parser::NodeType::NODE_BINARY_OP) return false;
+        sql_parser::StringRef op = cond->value();
+        if (op.len != 1 || op.ptr[0] != '=') return false;
+        const sql_parser::AstNode* l = cond->first_child;
+        const sql_parser::AstNode* r = l ? l->next_sibling : nullptr;
+        if (!l || !r) return false;
+        return (is_shard_key_ref(l, left_key) && is_shard_key_ref(r, right_key)) ||
+               (is_shard_key_ref(l, right_key) && is_shard_key_ref(r, left_key));
+    }
+
+    PlanNode* distribute_colocated_join(PlanNode* join_node,
+                                        const TableInfo* left_table,
+                                        const TableInfo* right_table) {
+        ScanContext lctx = extract_scan_context(join_node->left);
+        ScanContext rctx = extract_scan_context(join_node->right);
+        const sql_parser::AstNode* where_expr = nullptr;
+        if (lctx.where_expr && rctx.where_expr) {
+            sql_parser::AstNode* and_node = sql_parser::make_node(
+                arena_, sql_parser::NodeType::NODE_BINARY_OP,
+                sql_parser::StringRef{"AND", 3});
+            and_node->add_child(const_cast<sql_parser::AstNode*>(lctx.where_expr));
+            and_node->add_child(const_cast<sql_parser::AstNode*>(rctx.where_expr));
+            where_expr = and_node;
+        } else if (lctx.where_expr) {
+            where_expr = lctx.where_expr;
+        } else {
+            where_expr = rctx.where_expr;
+        }
+
+        const auto& shard_list = shards_.get_shards(left_table->table_name);
+        PlanNode* current = nullptr;
+        for (const auto& shard : shard_list) {
+            sql_parser::StringRef sql = qb_.build_select_join(
+                left_table, right_table, join_node->join.condition, where_expr);
+            PlanNode* rs = make_remote_scan(shard.backend_name.c_str(), sql, left_table);
+            if (!current) {
+                current = rs;
+            } else {
+                PlanNode* union_node = make_plan_node(arena_, PlanNodeType::SET_OP);
+                union_node->set_op.op = SET_OP_UNION;
+                union_node->set_op.all = true;
+                union_node->left = current;
+                union_node->right = rs;
+                current = union_node;
+            }
+        }
+        return current ? current : join_node;
+    }
+
     PlanNode* distribute_join(PlanNode* join_node) {
-        // Get tables from each side
         const TableInfo* left_table = find_table(join_node->left);
         const TableInfo* right_table = find_table(join_node->right);
+
+        if (left_table && right_table &&
+            shards_.is_sharded(left_table->table_name) &&
+            shards_.is_sharded(right_table->table_name) &&
+            shards_.same_routing(left_table->table_name, right_table->table_name) &&
+            join_on_shard_keys(join_node->join.condition,
+                               shards_.get_shard_key(left_table->table_name),
+                               shards_.get_shard_key(right_table->table_name))) {
+            return distribute_colocated_join(join_node, left_table, right_table);
+        }
 
         PlanNode* left_dist = nullptr;
         PlanNode* right_dist = nullptr;
@@ -1172,17 +1232,12 @@ private:
     PlanNode* distribute_update(PlanNode* plan) {
         const auto& up = plan->update_plan;
         const TableInfo* table = up.table;
-        if (!table || !shards_.has_table(table->table_name)) return plan;
 
-        // Multi-table UPDATE: emit full SQL from AST, route to primary table's backend
         if (up.original_ast) {
-            sql_parser::StringRef sql = qb_.build_update_from_ast(up.original_ast);
-            if (!shards_.is_sharded(table->table_name)) {
-                return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
-            }
-            const auto& shard_list = shards_.get_shards(table->table_name);
-            return scatter_dml_to_shards(table, shard_list, [&]() { return sql; });
+            return distribute_multi_table_dml(up.original_ast, table, true);
         }
+
+        if (!table || !shards_.has_table(table->table_name)) return plan;
 
         // Check for cross-shard subqueries in WHERE and rewrite
         const sql_parser::AstNode* where_expr = up.where_expr;
@@ -1220,17 +1275,12 @@ private:
     PlanNode* distribute_delete(PlanNode* plan) {
         const auto& dp = plan->delete_plan;
         const TableInfo* table = dp.table;
-        if (!table || !shards_.has_table(table->table_name)) return plan;
 
-        // Multi-table DELETE: emit full SQL from AST, route to primary table's backend
         if (dp.original_ast) {
-            sql_parser::StringRef sql = qb_.build_delete_from_ast(dp.original_ast);
-            if (!shards_.is_sharded(table->table_name)) {
-                return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
-            }
-            const auto& shard_list = shards_.get_shards(table->table_name);
-            return scatter_dml_to_shards(table, shard_list, [&]() { return sql; });
+            return distribute_multi_table_dml(dp.original_ast, table, false);
         }
+
+        if (!table || !shards_.has_table(table->table_name)) return plan;
 
         // Check for cross-shard subqueries in WHERE and rewrite
         const sql_parser::AstNode* where_expr = dp.where_expr;
@@ -1318,7 +1368,68 @@ private:
         return false;
     }
 
-    // Scatter DML SQL to all shards, combining results via UNION ALL
+    void collect_ast_table_names(const sql_parser::AstNode* n,
+                                 std::vector<sql_parser::StringRef>& out) const {
+        if (!n) return;
+        if (n->type == sql_parser::NodeType::NODE_TABLE_REF && n->first_child) {
+            const sql_parser::AstNode* name = n->first_child;
+            if (name->type == sql_parser::NodeType::NODE_IDENTIFIER) {
+                out.push_back(name->value());
+            } else if (name->type == sql_parser::NodeType::NODE_QUALIFIED_NAME) {
+                const sql_parser::AstNode* schema = name->first_child;
+                const sql_parser::AstNode* table = schema ? schema->next_sibling : nullptr;
+                if (table) out.push_back(table->value());
+                else if (schema) out.push_back(schema->value());
+            }
+        }
+        for (const sql_parser::AstNode* c = n->first_child; c; c = c->next_sibling) {
+            collect_ast_table_names(c, out);
+        }
+    }
+
+    PlanNode* distribute_multi_table_dml(const sql_parser::AstNode* ast,
+                                         const TableInfo* primary,
+                                         bool is_update) {
+        std::vector<sql_parser::StringRef> names;
+        collect_ast_table_names(ast, names);
+        const char* backend = nullptr;
+        bool saw_mapped = false;
+        for (sql_parser::StringRef name : names) {
+            if (!shards_.has_table(name)) continue;
+            saw_mapped = true;
+            if (shards_.is_sharded(name)) {
+                return fail_dml(is_update
+                    ? "multi-table UPDATE is not supported on sharded tables"
+                    : "multi-table DELETE is not supported on sharded tables");
+            }
+            const char* b = shards_.get_backend(name);
+            if (backend && b && std::strcmp(backend, b) != 0) {
+                return fail_dml(is_update
+                    ? "multi-table UPDATE spans multiple backends"
+                    : "multi-table DELETE spans multiple backends");
+            }
+            if (b) backend = b;
+        }
+        if (!backend && primary && shards_.has_table(primary->table_name)) {
+            if (shards_.is_sharded(primary->table_name)) {
+                return fail_dml(is_update
+                    ? "multi-table UPDATE is not supported on sharded tables"
+                    : "multi-table DELETE is not supported on sharded tables");
+            }
+            backend = shards_.get_backend(primary->table_name);
+            saw_mapped = true;
+        }
+        if (!backend || !saw_mapped) {
+            return fail_dml(is_update
+                ? "multi-table UPDATE is not supported on sharded tables"
+                : "multi-table DELETE is not supported on sharded tables");
+        }
+        sql_parser::StringRef sql = is_update
+            ? qb_.build_update_from_ast(ast)
+            : qb_.build_delete_from_ast(ast);
+        return make_remote_scan(backend, sql, primary);
+    }
+
     PlanNode* scatter_dml_to_shards(const TableInfo* table,
                                      const std::vector<ShardInfo>& shard_list,
                                      std::function<sql_parser::StringRef()> build_sql) {

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <climits>
 #include <vector>
 #include <unordered_map>
 #include <functional>
@@ -401,6 +402,62 @@ private:
                     }
                 }
             }
+            if (is_compare_op(op) &&
+                shards_.routing_strategy(table_name) == RoutingStrategy::RANGE) {
+                const sql_parser::AstNode* left_node = expr->first_child;
+                const sql_parser::AstNode* right_node = left_node ? left_node->next_sibling : nullptr;
+                if (left_node && right_node) {
+                    const sql_parser::AstNode* col = nullptr;
+                    const sql_parser::AstNode* lit = nullptr;
+                    bool key_on_left = false;
+                    if (is_shard_key_ref(left_node, shard_key) && is_literal(right_node)) {
+                        col = left_node; lit = right_node; key_on_left = true;
+                    } else if (is_shard_key_ref(right_node, shard_key) && is_literal(left_node)) {
+                        col = right_node; lit = left_node; key_on_left = false;
+                    }
+                    if (col && lit) {
+                        int64_t v = literal_to_int(lit);
+                        int64_t lo = INT64_MIN, hi = INT64_MAX;
+                        char c0 = op.ptr[0];
+                        bool has_eq = op.len == 2 && op.ptr[1] == '=';
+                        if (c0 == '<' && key_on_left) {
+                            hi = has_eq ? v : (v == INT64_MIN ? INT64_MIN : v - 1);
+                        } else if (c0 == '>' && key_on_left) {
+                            lo = has_eq ? v : (v == INT64_MAX ? INT64_MAX : v + 1);
+                        } else if (c0 == '<' && !key_on_left) {
+                            lo = has_eq ? v : (v == INT64_MAX ? INT64_MAX : v + 1);
+                        } else if (c0 == '>' && !key_on_left) {
+                            hi = has_eq ? v : (v == INT64_MIN ? INT64_MIN : v - 1);
+                        }
+                        shards_.collect_int_range_shards(table_name, lo, hi, target_indices);
+                        return;
+                    }
+                }
+            }
+            if (op.len == 2 &&
+                (op.ptr[0] == 'O' || op.ptr[0] == 'o') &&
+                (op.ptr[1] == 'R' || op.ptr[1] == 'r')) {
+                const sql_parser::AstNode* left_node = expr->first_child;
+                const sql_parser::AstNode* right_node = left_node ? left_node->next_sibling : nullptr;
+                std::vector<size_t> left_targets, right_targets;
+                extract_shard_targets(left_node, shard_key, table_name, num_shards, left_targets);
+                extract_shard_targets(right_node, shard_key, table_name, num_shards, right_targets);
+                if (left_targets.empty() || right_targets.empty()) return;
+                std::vector<bool> seen(num_shards, false);
+                for (auto i : left_targets) {
+                    if (i < num_shards && !seen[i]) {
+                        seen[i] = true;
+                        target_indices.push_back(i);
+                    }
+                }
+                for (auto i : right_targets) {
+                    if (i < num_shards && !seen[i]) {
+                        seen[i] = true;
+                        target_indices.push_back(i);
+                    }
+                }
+                return;
+            }
             // Recurse into AND branches
             if (op.len == 3 &&
                 (op.ptr[0] == 'A' || op.ptr[0] == 'a') &&
@@ -446,6 +503,29 @@ private:
                 }
             }
         }
+
+        if (expr->type == sql_parser::NodeType::NODE_BETWEEN &&
+            shards_.routing_strategy(table_name) == RoutingStrategy::RANGE) {
+            const sql_parser::AstNode* col = expr->first_child;
+            const sql_parser::AstNode* lo = col ? col->next_sibling : nullptr;
+            const sql_parser::AstNode* hi = lo ? lo->next_sibling : nullptr;
+            if (col && is_shard_key_ref(col, shard_key) && is_literal(lo) && is_literal(hi)) {
+                shards_.collect_int_range_shards(table_name,
+                                                 literal_to_int(lo), literal_to_int(hi),
+                                                 target_indices);
+            }
+        }
+    }
+
+    static bool is_compare_op(sql_parser::StringRef op) {
+        if (op.len == 1) return op.ptr[0] == '<' || op.ptr[0] == '>';
+        if (op.len == 2) return (op.ptr[0] == '<' || op.ptr[0] == '>') && op.ptr[1] == '=';
+        return false;
+    }
+
+    static int64_t literal_to_int(const sql_parser::AstNode* lit) {
+        if (!lit || !lit->value().ptr) return 0;
+        return std::strtoll(lit->value().ptr, nullptr, 10);
     }
 
     bool is_shard_key_ref(const sql_parser::AstNode* node, sql_parser::StringRef shard_key) const {

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -141,28 +141,38 @@ private:
             }
 
             case PlanNodeType::PROJECT: {
-                // Check for PROJECT -> [SORT ->] [FILTER ->] AGGREGATE pattern
-                // For aggregate queries, we want to handle the whole thing in distribute_aggregate
+                // PROJECT -> [SORT ->] [FILTER(HAVING) ->] AGGREGATE
+                PlanNode* sort_node = nullptr;
+                PlanNode* having_node = nullptr;
                 PlanNode* agg_child = node->left;
-                if (agg_child && agg_child->type == PlanNodeType::SORT)
+                if (agg_child && agg_child->type == PlanNodeType::SORT) {
+                    sort_node = agg_child;
                     agg_child = agg_child->left;
-                if (agg_child && agg_child->type == PlanNodeType::FILTER)
+                }
+                if (agg_child && agg_child->type == PlanNodeType::FILTER) {
+                    having_node = agg_child;
                     agg_child = agg_child->left;
+                }
                 if (agg_child && agg_child->type == PlanNodeType::AGGREGATE) {
-                    // Extract aggregate info from the PROJECT select list
                     push_agg_exprs_from_project(node, agg_child);
                     PlanNode* dist_agg = distribute_aggregate(agg_child);
-                    if (dist_agg && dist_agg->type == PlanNodeType::MERGE_AGGREGATE) {
-                        // Re-add FILTER (HAVING) if present
-                        if (node->left && node->left->type == PlanNodeType::FILTER) {
+                    if (dist_agg && (dist_agg->type == PlanNodeType::MERGE_AGGREGATE ||
+                                     dist_agg->type == PlanNodeType::AGGREGATE)) {
+                        PlanNode* top = dist_agg;
+                        if (having_node) {
                             PlanNode* having = make_plan_node(arena_, PlanNodeType::FILTER);
-                            having->filter.expr = node->left->filter.expr;
-                            having->left = dist_agg;
-                            return having;
+                            having->filter.expr = having_node->filter.expr;
+                            having->left = top;
+                            top = having;
                         }
-                        return dist_agg;
+                        if (sort_node) {
+                            PlanNode* sort = make_plan_node(arena_, PlanNodeType::SORT);
+                            sort->sort = sort_node->sort;
+                            sort->left = top;
+                            top = sort;
+                        }
+                        return top;
                     }
-                    // For unsharded, the remote already computes everything
                     return dist_agg;
                 }
 
@@ -188,6 +198,13 @@ private:
 
             case PlanNodeType::JOIN:
                 return distribute_join(node);
+
+            case PlanNodeType::WINDOW: {
+                PlanNode* result = make_plan_node(arena_, PlanNodeType::WINDOW);
+                result->window = node->window;
+                result->left = distribute_node(node->left);
+                return result;
+            }
 
             case PlanNodeType::SET_OP: {
                 PlanNode* result = make_plan_node(arena_, PlanNodeType::SET_OP);
@@ -259,6 +276,24 @@ private:
         }
         ctx = extract_scan_context(node->left);
         return ctx;
+    }
+
+    static bool contains_type(const PlanNode* node, PlanNodeType type) {
+        if (!node) return false;
+        if (node->type == type) return true;
+        if (contains_type(node->left, type)) return true;
+        if (contains_type(node->right, type)) return true;
+        if (node->type == PlanNodeType::MERGE_AGGREGATE) {
+            for (uint16_t i = 0; i < node->merge_aggregate.child_count; ++i) {
+                if (contains_type(node->merge_aggregate.children[i], type)) return true;
+            }
+        }
+        if (node->type == PlanNodeType::MERGE_SORT) {
+            for (uint16_t i = 0; i < node->merge_sort.child_count; ++i) {
+                if (contains_type(node->merge_sort.children[i], type)) return true;
+            }
+        }
+        return false;
     }
 
     // Case 1 & 2: Distribute a scan (possibly with filter pushed down)
@@ -548,8 +583,14 @@ private:
 
         const TableInfo* table = ctx.scan->scan.table;
         if (!shards_.has_table(table->table_name) || !shards_.is_sharded(table->table_name)) {
-            // Unsharded -- push the whole thing to remote
             return make_unsharded_aggregate(agg_node, ctx, table);
+        }
+
+        if (!all_aggregates_two_phase(agg_node)) {
+            PlanNode* result = make_plan_node(arena_, PlanNodeType::AGGREGATE);
+            result->aggregate = agg_node->aggregate;
+            result->left = distribute_node(agg_node->left);
+            return result;
         }
 
         // Sharded aggregate: each shard computes partial aggregates.
@@ -661,6 +702,24 @@ private:
         return make_remote_scan_with_outputs(backend, sql, table, projs);
     }
 
+    static bool is_two_phase_aggregate(const sql_parser::AstNode* expr) {
+        if (!expr || expr->type != sql_parser::NodeType::NODE_FUNCTION_CALL) return false;
+        if (expr->flags & sql_parser::FLAG_FUNC_DISTINCT) return false;
+        sql_parser::StringRef name = expr->value();
+        return name.equals_ci("COUNT", 5) || name.equals_ci("SUM", 3) ||
+               name.equals_ci("AVG", 3) || name.equals_ci("MIN", 3) ||
+               name.equals_ci("MAX", 3);
+    }
+
+    bool all_aggregates_two_phase(const PlanNode* agg_node) const {
+        if (!agg_node) return false;
+        if (agg_node->aggregate.agg_count == 0) return true;
+        for (uint16_t i = 0; i < agg_node->aggregate.agg_count; ++i) {
+            if (!is_two_phase_aggregate(agg_node->aggregate.agg_exprs[i])) return false;
+        }
+        return true;
+    }
+
     void decompose_aggregate(const sql_parser::AstNode* expr,
                               std::vector<const sql_parser::AstNode*>& projs,
                               std::vector<uint8_t>& merge_ops) {
@@ -673,11 +732,9 @@ private:
         sql_parser::StringRef name = expr->value();
 
         if (name.equals_ci("COUNT", 5)) {
-            // Remote: COUNT(*) or COUNT(col), Local: SUM of counts
             projs.push_back(expr);
             merge_ops.push_back(static_cast<uint8_t>(MergeOp::SUM_OF_COUNTS));
         } else if (name.equals_ci("SUM", 3)) {
-            // Remote: SUM(col), Local: SUM of sums
             projs.push_back(expr);
             merge_ops.push_back(static_cast<uint8_t>(MergeOp::SUM_OF_SUMS));
         } else if (name.equals_ci("AVG", 3)) {
@@ -726,7 +783,16 @@ private:
 
     // Case 4: Distributed sort + limit
     PlanNode* distribute_sort(PlanNode* sort_node) {
-        // Check if the child is a scan (possibly through filter) on a sharded table
+        if (contains_type(sort_node->left, PlanNodeType::WINDOW) ||
+            contains_type(sort_node->left, PlanNodeType::DERIVED_SCAN) ||
+            contains_type(sort_node->left, PlanNodeType::AGGREGATE) ||
+            contains_type(sort_node->left, PlanNodeType::MERGE_AGGREGATE)) {
+            PlanNode* result = make_plan_node(arena_, PlanNodeType::SORT);
+            result->sort = sort_node->sort;
+            result->left = distribute_node(sort_node->left);
+            return result;
+        }
+
         ScanContext ctx = extract_scan_context(sort_node->left);
         if (!ctx.scan || !ctx.scan->scan.table) {
             PlanNode* result = make_plan_node(arena_, PlanNodeType::SORT);
@@ -795,6 +861,15 @@ private:
         // Check if child is Sort on sharded table
         if (limit_node->left && limit_node->left->type == PlanNodeType::SORT) {
             PlanNode* sort_node = limit_node->left;
+            if (contains_type(sort_node->left, PlanNodeType::WINDOW) ||
+                contains_type(sort_node->left, PlanNodeType::DERIVED_SCAN) ||
+                contains_type(sort_node->left, PlanNodeType::AGGREGATE) ||
+                contains_type(sort_node->left, PlanNodeType::MERGE_AGGREGATE)) {
+                PlanNode* result = make_plan_node(arena_, PlanNodeType::LIMIT);
+                result->limit = limit_node->limit;
+                result->left = distribute_node(limit_node->left);
+                return result;
+            }
             ScanContext ctx = extract_scan_context(sort_node->left);
             if (ctx.scan && ctx.scan->scan.table) {
                 const TableInfo* table = ctx.scan->scan.table;
@@ -839,7 +914,16 @@ private:
             }
         }
 
-        // Check if child is scan on sharded/unsharded table (limit without sort)
+        if (contains_type(limit_node->left, PlanNodeType::WINDOW) ||
+            contains_type(limit_node->left, PlanNodeType::DERIVED_SCAN) ||
+            contains_type(limit_node->left, PlanNodeType::AGGREGATE) ||
+            contains_type(limit_node->left, PlanNodeType::MERGE_AGGREGATE)) {
+            PlanNode* result = make_plan_node(arena_, PlanNodeType::LIMIT);
+            result->limit = limit_node->limit;
+            result->left = distribute_node(limit_node->left);
+            return result;
+        }
+
         ScanContext ctx = extract_scan_context(limit_node->left);
         if (ctx.scan && ctx.scan->scan.table) {
             const TableInfo* table = ctx.scan->scan.table;

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -206,6 +206,13 @@ private:
                 return result;
             }
 
+            case PlanNodeType::DERIVED_SCAN: {
+                PlanNode* result = make_plan_node(arena_, PlanNodeType::DERIVED_SCAN);
+                result->derived_scan = node->derived_scan;
+                result->derived_scan.inner_plan = distribute(node->derived_scan.inner_plan);
+                return result;
+            }
+
             case PlanNodeType::SET_OP: {
                 PlanNode* result = make_plan_node(arena_, PlanNodeType::SET_OP);
                 result->set_op = node->set_op;
@@ -292,6 +299,9 @@ private:
             for (uint16_t i = 0; i < node->merge_sort.child_count; ++i) {
                 if (contains_type(node->merge_sort.children[i], type)) return true;
             }
+        }
+        if (node->type == PlanNodeType::DERIVED_SCAN) {
+            return contains_type(node->derived_scan.inner_plan, type);
         }
         return false;
     }
@@ -545,7 +555,7 @@ private:
         std::memcpy(bn, backend, blen + 1);
         node->remote_scan.backend_name = bn;
         node->remote_scan.remote_sql = sql.ptr;
-        node->remote_scan.remote_sql_len = static_cast<uint16_t>(sql.len);
+        node->remote_scan.remote_sql_len = sql.len;
         node->remote_scan.table = table;
         // Caller is responsible for setting output_exprs when the remote SQL
         // is not a passthrough SELECT *. make_plan_node() already zero-fills
@@ -782,15 +792,53 @@ private:
     }
 
     // Case 4: Distributed sort + limit
+    PlanNode* local_sort(PlanNode* sort_node) {
+        PlanNode* result = make_plan_node(arena_, PlanNodeType::SORT);
+        result->sort = sort_node->sort;
+        result->left = distribute_node(sort_node->left);
+        return result;
+    }
+
+    int sort_key_table_ordinal(const sql_parser::AstNode* key, const TableInfo* table) const {
+        if (!key || !table) return -1;
+        if (key->type == sql_parser::NodeType::NODE_LITERAL_INT) {
+            sql_parser::StringRef sv = key->value();
+            if (!sv.ptr || sv.len == 0) return -1;
+            int64_t n = std::strtoll(sv.ptr, nullptr, 10);
+            if (n < 1 || n > static_cast<int64_t>(table->column_count)) return -1;
+            return static_cast<int>(n - 1);
+        }
+        sql_parser::StringRef col_name;
+        if (key->type == sql_parser::NodeType::NODE_COLUMN_REF ||
+            key->type == sql_parser::NodeType::NODE_IDENTIFIER) {
+            col_name = key->value();
+        } else if (key->type == sql_parser::NodeType::NODE_QUALIFIED_NAME) {
+            const sql_parser::AstNode* c = key->first_child;
+            if (c && c->next_sibling) col_name = c->next_sibling->value();
+            else if (c) col_name = c->value();
+        } else {
+            return -1;
+        }
+        if (!col_name.ptr) return -1;
+        const ColumnInfo* col = catalog_.get_column(table, col_name);
+        if (!col) return -1;
+        return static_cast<int>(col->ordinal);
+    }
+
+    bool all_sort_keys_are_table_columns(const PlanNode* sort_node, const TableInfo* table) const {
+        if (!sort_node || !table) return false;
+        for (uint16_t i = 0; i < sort_node->sort.count; ++i) {
+            if (sort_key_table_ordinal(sort_node->sort.keys[i], table) < 0) return false;
+        }
+        return true;
+    }
+
     PlanNode* distribute_sort(PlanNode* sort_node) {
         if (contains_type(sort_node->left, PlanNodeType::WINDOW) ||
             contains_type(sort_node->left, PlanNodeType::DERIVED_SCAN) ||
             contains_type(sort_node->left, PlanNodeType::AGGREGATE) ||
             contains_type(sort_node->left, PlanNodeType::MERGE_AGGREGATE)) {
-            PlanNode* result = make_plan_node(arena_, PlanNodeType::SORT);
-            result->sort = sort_node->sort;
-            result->left = distribute_node(sort_node->left);
-            return result;
+            return local_sort(sort_node);
         }
 
         ScanContext ctx = extract_scan_context(sort_node->left);
@@ -807,6 +855,10 @@ private:
             result->sort = sort_node->sort;
             result->left = distribute_node(sort_node->left);
             return result;
+        }
+
+        if (!all_sort_keys_are_table_columns(sort_node, table)) {
+            return local_sort(sort_node);
         }
 
         if (!shards_.is_sharded(table->table_name)) {
@@ -875,8 +927,12 @@ private:
                 const TableInfo* table = ctx.scan->scan.table;
                 if (shards_.has_table(table->table_name) &&
                     shards_.is_sharded(table->table_name)) {
-                    // Case 4: Sharded sort + limit
-                    // Each shard: ORDER BY + LIMIT, MergeSort, then outer Limit
+                    if (!all_sort_keys_are_table_columns(sort_node, table)) {
+                        PlanNode* result = make_plan_node(arena_, PlanNodeType::LIMIT);
+                        result->limit = limit_node->limit;
+                        result->left = distribute_node(limit_node->left);
+                        return result;
+                    }
                     int64_t remote_limit = limit_node->limit.count + limit_node->limit.offset;
 
                     PlanNode* merge = make_sharded_merge_sort(

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -12,9 +12,12 @@
 #include "sql_engine/result_set.h"
 #include "sql_engine/plan_builder.h"
 #include "sql_engine/plan_executor.h"
+#include "sql_engine/catalog_resolver.h"
 #include "sql_parser/arena.h"
 #include "sql_parser/ast.h"
 #include "sql_parser/common.h"
+#include "sql_parser/string_builder.h"
+#include "sql_parser/emitter.h"
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
@@ -22,6 +25,7 @@
 #include <vector>
 #include <unordered_map>
 #include <functional>
+#include <utility>
 
 namespace sql_engine {
 
@@ -318,7 +322,8 @@ private:
         const TableInfo* table = scan_node->scan.table;
         if (!table) return scan_node;
 
-        if (!shards_.has_table(table->table_name)) return scan_node;
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
 
         if (!shards_.is_sharded(table->table_name)) {
             // Case 1: Unsharded -- single RemoteScan
@@ -348,13 +353,18 @@ private:
                                          const std::vector<ShardInfo>& all_shards) {
         if (!where_expr || all_shards.empty()) return all_shards;
 
-        sql_parser::StringRef shard_key = shards_.get_shard_key(table->table_name);
-        if (!shard_key.ptr || shard_key.len == 0) return all_shards;
+        const auto& keys = shards_.get_shard_keys(table->table_name);
+        if (keys.empty()) return all_shards;
 
-        // Try to extract shard key literal values from WHERE expression
         std::vector<size_t> target_indices;
-        extract_shard_targets(where_expr, shard_key, table->table_name,
-                              all_shards.size(), target_indices);
+        if (keys.size() > 1) {
+            extract_composite_targets(where_expr, keys, table->table_name, target_indices);
+        } else {
+            sql_parser::StringRef shard_key{keys[0].c_str(),
+                static_cast<uint32_t>(keys[0].size())};
+            extract_shard_targets(where_expr, shard_key, table->table_name,
+                                  all_shards.size(), target_indices);
+        }
 
         if (target_indices.empty()) return all_shards;
 
@@ -396,8 +406,9 @@ private:
                         col_node = right_node; lit_node = left_node;
                     }
                     if (col_node && lit_node) {
-                        size_t idx = literal_to_shard_index(lit_node, table_name, num_shards);
-                        target_indices.push_back(idx);
+                        size_t idx = 0;
+                        if (try_literal_to_shard_index(lit_node, table_name, idx))
+                            target_indices.push_back(idx);
                         return;
                     }
                 }
@@ -494,7 +505,9 @@ private:
             if (col_expr && is_shard_key_ref(col_expr, shard_key)) {
                 for (const sql_parser::AstNode* item = col_expr->next_sibling; item; item = item->next_sibling) {
                     if (is_literal(item)) {
-                        target_indices.push_back(literal_to_shard_index(item, table_name, num_shards));
+                        size_t idx = 0;
+                        if (try_literal_to_shard_index(item, table_name, idx))
+                            target_indices.push_back(idx);
                     } else {
                         // Non-literal in IN list -- can't prune
                         target_indices.clear();
@@ -504,15 +517,23 @@ private:
             }
         }
 
-        if (expr->type == sql_parser::NodeType::NODE_BETWEEN &&
-            shards_.routing_strategy(table_name) == RoutingStrategy::RANGE) {
-            const sql_parser::AstNode* col = expr->first_child;
-            const sql_parser::AstNode* lo = col ? col->next_sibling : nullptr;
-            const sql_parser::AstNode* hi = lo ? lo->next_sibling : nullptr;
-            if (col && is_shard_key_ref(col, shard_key) && is_literal(lo) && is_literal(hi)) {
-                shards_.collect_int_range_shards(table_name,
-                                                 literal_to_int(lo), literal_to_int(hi),
-                                                 target_indices);
+        if (expr->type == sql_parser::NodeType::NODE_BETWEEN) {
+            RoutingStrategy strat = shards_.routing_strategy(table_name);
+            if (strat == RoutingStrategy::RANGE || strat == RoutingStrategy::LIST) {
+                const sql_parser::AstNode* col = expr->first_child;
+                const sql_parser::AstNode* lo = col ? col->next_sibling : nullptr;
+                const sql_parser::AstNode* hi = lo ? lo->next_sibling : nullptr;
+                if (col && is_shard_key_ref(col, shard_key) && is_literal(lo) && is_literal(hi)) {
+                    if (strat == RoutingStrategy::RANGE) {
+                        shards_.collect_int_range_shards(table_name,
+                                                         literal_to_int(lo), literal_to_int(hi),
+                                                         target_indices);
+                    } else {
+                        shards_.collect_int_list_shards(table_name,
+                                                        literal_to_int(lo), literal_to_int(hi),
+                                                        target_indices);
+                    }
+                }
             }
         }
     }
@@ -551,27 +572,27 @@ private:
                node->type == sql_parser::NodeType::NODE_LITERAL_STRING;
     }
 
-    size_t literal_to_shard_index(const sql_parser::AstNode* lit,
+    bool try_literal_to_shard_index(const sql_parser::AstNode* lit,
                                     sql_parser::StringRef table_name,
-                                    size_t num_shards) const {
-        if (!lit || num_shards == 0) return 0;
+                                    size_t& out) const {
+        if (!lit) return false;
         if (lit->type == sql_parser::NodeType::NODE_LITERAL_INT) {
             sql_parser::StringRef sv = lit->value();
             int64_t val = 0;
             if (sv.ptr && sv.len > 0) val = std::strtoll(sv.ptr, nullptr, 10);
-            return shards_.shard_index_for_int(table_name, val);
+            return shards_.try_shard_index_for_int(table_name, val, out);
         }
         if (lit->type == sql_parser::NodeType::NODE_LITERAL_STRING) {
             sql_parser::StringRef sv = lit->value();
-            return shards_.shard_index_for_string(table_name, sv.ptr, sv.len);
+            return shards_.try_shard_index_for_string(table_name, sv.ptr, sv.len, out);
         }
         if (lit->type == sql_parser::NodeType::NODE_LITERAL_FLOAT) {
             sql_parser::StringRef sv = lit->value();
             double dv = sv.ptr ? std::strtod(sv.ptr, nullptr) : 0.0;
-            int64_t iv = static_cast<int64_t>(dv);
-            return shards_.shard_index_for_int(table_name, iv);
+            return shards_.try_shard_index_for_int(
+                table_name, static_cast<int64_t>(dv), out);
         }
-        return 0;
+        return false;
     }
 
     // Build N RemoteScans with UNION ALL
@@ -628,6 +649,7 @@ private:
 
     PlanNode* make_remote_scan(const char* backend, sql_parser::StringRef sql,
                                 const TableInfo* table) {
+        if (!backend) return fail_dml("table not in shard map");
         PlanNode* node = make_plan_node(arena_, PlanNodeType::REMOTE_SCAN);
         // Copy backend name to arena
         uint32_t blen = static_cast<uint32_t>(std::strlen(backend));
@@ -672,7 +694,9 @@ private:
         }
 
         const TableInfo* table = ctx.scan->scan.table;
-        if (!shards_.has_table(table->table_name) || !shards_.is_sharded(table->table_name)) {
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
+        if (!shards_.is_sharded(table->table_name)) {
             return make_unsharded_aggregate(agg_node, ctx, table);
         }
 
@@ -930,12 +954,8 @@ private:
         }
 
         const TableInfo* table = ctx.scan->scan.table;
-        if (!shards_.has_table(table->table_name)) {
-            PlanNode* result = make_plan_node(arena_, PlanNodeType::SORT);
-            result->sort = sort_node->sort;
-            result->left = distribute_node(sort_node->left);
-            return result;
-        }
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
 
         if (!all_sort_keys_are_table_columns(sort_node, table)) {
             return local_sort(sort_node);
@@ -1092,6 +1112,58 @@ private:
                (is_shard_key_ref(l, right_key) && is_shard_key_ref(r, left_key));
     }
 
+    void collect_eq_pairs(const sql_parser::AstNode* expr,
+                          std::vector<std::pair<const sql_parser::AstNode*,
+                                                const sql_parser::AstNode*>>& out) const {
+        if (!expr || expr->type != sql_parser::NodeType::NODE_BINARY_OP) return;
+        sql_parser::StringRef op = expr->value();
+        if (op.len == 1 && op.ptr[0] == '=') {
+            const sql_parser::AstNode* l = expr->first_child;
+            const sql_parser::AstNode* r = l ? l->next_sibling : nullptr;
+            if (l && r) out.push_back({l, r});
+            return;
+        }
+        if (op.len == 3 &&
+            (op.ptr[0] == 'A' || op.ptr[0] == 'a') &&
+            (op.ptr[1] == 'N' || op.ptr[1] == 'n') &&
+            (op.ptr[2] == 'D' || op.ptr[2] == 'd')) {
+            collect_eq_pairs(expr->first_child, out);
+            if (expr->first_child)
+                collect_eq_pairs(expr->first_child->next_sibling, out);
+        }
+    }
+
+    bool join_covers_composite_keys(const sql_parser::AstNode* cond,
+                                    const std::vector<std::string>& left_keys,
+                                    const std::vector<std::string>& right_keys) const {
+        if (left_keys.empty() || left_keys.size() != right_keys.size()) return false;
+        if (left_keys.size() == 1) {
+            sql_parser::StringRef lk{left_keys[0].c_str(),
+                static_cast<uint32_t>(left_keys[0].size())};
+            sql_parser::StringRef rk{right_keys[0].c_str(),
+                static_cast<uint32_t>(right_keys[0].size())};
+            return join_on_shard_keys(cond, lk, rk);
+        }
+        std::vector<std::pair<const sql_parser::AstNode*, const sql_parser::AstNode*>> eqs;
+        collect_eq_pairs(cond, eqs);
+        for (size_t i = 0; i < left_keys.size(); ++i) {
+            sql_parser::StringRef lk{left_keys[i].c_str(),
+                static_cast<uint32_t>(left_keys[i].size())};
+            sql_parser::StringRef rk{right_keys[i].c_str(),
+                static_cast<uint32_t>(right_keys[i].size())};
+            bool found = false;
+            for (const auto& eq : eqs) {
+                if ((is_shard_key_ref(eq.first, lk) && is_shard_key_ref(eq.second, rk)) ||
+                    (is_shard_key_ref(eq.first, rk) && is_shard_key_ref(eq.second, lk))) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return false;
+        }
+        return true;
+    }
+
     PlanNode* distribute_colocated_join(PlanNode* join_node,
                                         const TableInfo* left_table,
                                         const TableInfo* right_table) {
@@ -1139,9 +1211,9 @@ private:
             shards_.is_sharded(left_table->table_name) &&
             shards_.is_sharded(right_table->table_name) &&
             shards_.same_routing(left_table->table_name, right_table->table_name) &&
-            join_on_shard_keys(join_node->join.condition,
-                               shards_.get_shard_key(left_table->table_name),
-                               shards_.get_shard_key(right_table->table_name))) {
+            join_covers_composite_keys(join_node->join.condition,
+                                       shards_.get_shard_keys(left_table->table_name),
+                                       shards_.get_shard_keys(right_table->table_name))) {
             return distribute_colocated_join(join_node, left_table, right_table);
         }
 
@@ -1198,7 +1270,9 @@ private:
     PlanNode* distribute_insert(PlanNode* plan) {
         const auto& ip = plan->insert_plan;
         const TableInfo* table = ip.table;
-        if (!table || !shards_.has_table(table->table_name)) return plan;
+        if (!table) return plan;
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
 
         // Check for INSERT ... SELECT (select_source stores the SELECT AST)
         if (ip.select_source && ip.select_source->type == PlanNodeType::DERIVED_SCAN
@@ -1217,53 +1291,44 @@ private:
             return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
         }
 
-        // Sharded: group rows by shard key value
-        sql_parser::StringRef shard_key = shards_.get_shard_key(table->table_name);
-        if (!shard_key.ptr) return plan;
+        const auto& key_names = shards_.get_shard_keys(table->table_name);
+        if (key_names.empty()) return plan;
 
-        // Find shard key column ordinal in the column list
-        int shard_col_idx = -1;
-        if (ip.columns && ip.column_count > 0) {
-            for (uint16_t i = 0; i < ip.column_count; ++i) {
-                if (ip.columns[i] && ip.columns[i]->value().equals_ci(shard_key.ptr, shard_key.len)) {
-                    shard_col_idx = static_cast<int>(i);
-                    break;
-                }
-            }
-        } else if (table) {
-            // No explicit column list -- match by table column order
-            for (uint16_t i = 0; i < table->column_count; ++i) {
-                if (table->columns[i].name.equals_ci(shard_key.ptr, shard_key.len)) {
-                    shard_col_idx = static_cast<int>(i);
-                    break;
-                }
-            }
+        std::vector<int> key_ords(key_names.size(), -1);
+        for (size_t k = 0; k < key_names.size(); ++k) {
+            sql_parser::StringRef kn{key_names[k].c_str(),
+                static_cast<uint32_t>(key_names[k].size())};
+            key_ords[k] = find_insert_key_ordinal(ip.columns, ip.column_count, table, kn);
         }
-
-        if (shard_col_idx < 0) {
-            return fail_dml("cannot route INSERT: shard key column is not present");
+        for (int ord : key_ords) {
+            if (ord < 0)
+                return fail_dml("cannot route INSERT: shard key column is not present");
         }
 
         const auto& shard_list = shards_.get_shards(table->table_name);
 
-        // Group rows by ShardMap route. Map: shard_index -> list of row indices.
         std::unordered_map<size_t, std::vector<uint16_t>> shard_rows;
 
         for (uint16_t ri = 0; ri < ip.row_count; ++ri) {
             const sql_parser::AstNode* row_ast = ip.value_rows[ri];
             if (!row_ast) continue;
 
-            const sql_parser::AstNode* expr = row_ast->first_child;
-            for (int j = 0; j < shard_col_idx && expr; ++j) {
-                expr = expr->next_sibling;
+            std::vector<ShardKeyPart> parts;
+            parts.reserve(key_ords.size());
+            for (int ord : key_ords) {
+                const sql_parser::AstNode* expr = row_ast->first_child;
+                for (int j = 0; j < ord && expr; ++j) expr = expr->next_sibling;
+                if (!expr)
+                    return fail_dml("cannot route INSERT: missing shard key value");
+                Value v = evaluate_shard_key_value(expr);
+                if (!value_is_routable(v))
+                    return fail_dml("cannot route INSERT: shard key is not a literal");
+                parts.push_back(value_to_part(v));
             }
-            if (!expr) {
-                return fail_dml("cannot route INSERT: missing shard key value");
-            }
-
             size_t shard_idx = 0;
-            if (!route_value(table->table_name, evaluate_shard_key_value(expr), shard_idx)) {
-                return fail_dml("cannot route INSERT: shard key is not a literal");
+            if (!shards_.try_shard_index_for_parts(table->table_name, parts.data(),
+                                                   parts.size(), shard_idx)) {
+                return fail_dml("cannot route INSERT: shard key value is not mapped");
             }
             shard_rows[shard_idx].push_back(ri);
         }
@@ -1317,7 +1382,9 @@ private:
             return distribute_multi_table_dml(up.original_ast, table, true);
         }
 
-        if (!table || !shards_.has_table(table->table_name)) return plan;
+        if (!table) return plan;
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
 
         // Check for cross-shard subqueries in WHERE and rewrite
         const sql_parser::AstNode* where_expr = up.where_expr;
@@ -1332,9 +1399,8 @@ private:
             return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
         }
 
-        sql_parser::StringRef shard_key = shards_.get_shard_key(table->table_name);
-        if (assigns_shard_key(up.set_columns, up.set_count, shard_key)) {
-            return fail_dml("cannot UPDATE shard key column");
+        if (assigns_any_shard_key(up.set_columns, up.set_count, table->table_name)) {
+            return distribute_update_move(plan, table, where_expr);
         }
 
         const auto& shard_list = shards_.get_shards(table->table_name);
@@ -1360,7 +1426,9 @@ private:
             return distribute_multi_table_dml(dp.original_ast, table, false);
         }
 
-        if (!table || !shards_.has_table(table->table_name)) return plan;
+        if (!table) return plan;
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
 
         // Check for cross-shard subqueries in WHERE and rewrite
         const sql_parser::AstNode* where_expr = dp.where_expr;
@@ -1413,19 +1481,16 @@ private:
     }
 
     bool route_value(sql_parser::StringRef table_name, const Value& v, size_t& shard_idx) const {
-        if (v.tag == Value::TAG_INT64) {
-            shard_idx = shards_.shard_index_for_int(table_name, v.int_val);
-            return true;
-        }
+        if (!shards_.has_table(table_name)) return false;
+        if (v.tag == Value::TAG_INT64)
+            return shards_.try_shard_index_for_int(table_name, v.int_val, shard_idx);
         if (v.tag == Value::TAG_UINT64) {
-            shard_idx = shards_.shard_index_for_int(
-                table_name, static_cast<int64_t>(v.uint_val));
-            return true;
+            return shards_.try_shard_index_for_int(
+                table_name, static_cast<int64_t>(v.uint_val), shard_idx);
         }
         if (v.tag == Value::TAG_STRING && v.str_val.ptr) {
-            shard_idx = shards_.shard_index_for_string(
-                table_name, v.str_val.ptr, v.str_val.len);
-            return true;
+            return shards_.try_shard_index_for_string(
+                table_name, v.str_val.ptr, v.str_val.len, shard_idx);
         }
         return false;
     }
@@ -1437,6 +1502,341 @@ private:
             if (is_column_ref(set_columns[i], shard_key)) return true;
         }
         return false;
+    }
+
+    bool assigns_any_shard_key(const sql_parser::AstNode** set_columns, uint16_t set_count,
+                               sql_parser::StringRef table_name) const {
+        for (const auto& k : shards_.get_shard_keys(table_name)) {
+            sql_parser::StringRef kn{k.c_str(), static_cast<uint32_t>(k.size())};
+            if (assigns_shard_key(set_columns, set_count, kn)) return true;
+        }
+        return false;
+    }
+
+    static bool value_is_routable(const Value& v) {
+        return v.tag == Value::TAG_INT64 || v.tag == Value::TAG_UINT64 ||
+               (v.tag == Value::TAG_STRING && v.str_val.ptr);
+    }
+
+    static ShardKeyPart value_to_part(const Value& v) {
+        ShardKeyPart p;
+        if (v.tag == Value::TAG_INT64) {
+            p.is_int = true;
+            p.int_val = v.int_val;
+        } else if (v.tag == Value::TAG_UINT64) {
+            p.is_int = true;
+            p.int_val = static_cast<int64_t>(v.uint_val);
+        } else {
+            p.is_int = false;
+            p.str = v.str_val.ptr;
+            p.str_len = v.str_val.len;
+        }
+        return p;
+    }
+
+    static int find_insert_key_ordinal(const sql_parser::AstNode** columns,
+                                       uint16_t column_count,
+                                       const TableInfo* table,
+                                       sql_parser::StringRef key) {
+        if (columns && column_count > 0) {
+            for (uint16_t i = 0; i < column_count; ++i) {
+                if (columns[i] && columns[i]->value().equals_ci(key.ptr, key.len))
+                    return static_cast<int>(i);
+            }
+            return -1;
+        }
+        if (!table) return -1;
+        for (uint16_t i = 0; i < table->column_count; ++i) {
+            if (table->columns[i].name.equals_ci(key.ptr, key.len))
+                return static_cast<int>(i);
+        }
+        return -1;
+    }
+
+    void collect_key_eq_values(const sql_parser::AstNode* expr,
+                               sql_parser::StringRef key,
+                               std::vector<Value>& out) {
+        if (!expr) return;
+        if (expr->type == sql_parser::NodeType::NODE_BINARY_OP) {
+            sql_parser::StringRef op = expr->value();
+            if (op.len == 1 && op.ptr[0] == '=') {
+                const sql_parser::AstNode* l = expr->first_child;
+                const sql_parser::AstNode* r = l ? l->next_sibling : nullptr;
+                if (l && r) {
+                    const sql_parser::AstNode* lit = nullptr;
+                    if (is_shard_key_ref(l, key) && is_literal(r)) lit = r;
+                    else if (is_shard_key_ref(r, key) && is_literal(l)) lit = l;
+                    if (lit) {
+                        Value v = evaluate_shard_key_value(lit);
+                        if (value_is_routable(v)) out.push_back(v);
+                    }
+                }
+                return;
+            }
+            if (op.len == 3 &&
+                (op.ptr[0] == 'A' || op.ptr[0] == 'a') &&
+                (op.ptr[1] == 'N' || op.ptr[1] == 'n') &&
+                (op.ptr[2] == 'D' || op.ptr[2] == 'd')) {
+                collect_key_eq_values(expr->first_child, key, out);
+                if (expr->first_child)
+                    collect_key_eq_values(expr->first_child->next_sibling, key, out);
+            }
+            return;
+        }
+        if (expr->type == sql_parser::NodeType::NODE_IN_LIST) {
+            const sql_parser::AstNode* col = expr->first_child;
+            if (col && is_shard_key_ref(col, key)) {
+                for (const sql_parser::AstNode* item = col->next_sibling; item;
+                     item = item->next_sibling) {
+                    if (!is_literal(item)) {
+                        out.clear();
+                        return;
+                    }
+                    Value v = evaluate_shard_key_value(item);
+                    if (value_is_routable(v)) out.push_back(v);
+                }
+            }
+        }
+    }
+
+    void extract_composite_targets(const sql_parser::AstNode* where_expr,
+                                   const std::vector<std::string>& keys,
+                                   sql_parser::StringRef table_name,
+                                   std::vector<size_t>& target_indices) {
+        std::vector<std::vector<Value>> dims(keys.size());
+        for (size_t k = 0; k < keys.size(); ++k) {
+            sql_parser::StringRef kn{keys[k].c_str(),
+                static_cast<uint32_t>(keys[k].size())};
+            collect_key_eq_values(where_expr, kn, dims[k]);
+            if (dims[k].empty()) return;
+        }
+        std::vector<size_t> cursor(keys.size(), 0);
+        for (;;) {
+            std::vector<ShardKeyPart> parts(keys.size());
+            for (size_t k = 0; k < keys.size(); ++k)
+                parts[k] = value_to_part(dims[k][cursor[k]]);
+            size_t idx = 0;
+            if (shards_.try_shard_index_for_parts(table_name, parts.data(),
+                                                  parts.size(), idx))
+                target_indices.push_back(idx);
+            size_t d = keys.size();
+            while (d-- > 0) {
+                if (++cursor[d] < dims[d].size()) break;
+                cursor[d] = 0;
+            }
+            if (d == static_cast<size_t>(-1)) break;
+        }
+    }
+
+    PlanNode* append_remote(PlanNode* current, PlanNode* next) {
+        if (!next) return current;
+        if (!current) return next;
+        PlanNode* union_node = make_plan_node(arena_, PlanNodeType::SET_OP);
+        union_node->set_op.op = SET_OP_UNION;
+        union_node->set_op.all = true;
+        union_node->left = current;
+        union_node->right = next;
+        return union_node;
+    }
+
+    Value copy_value_arena(const Value& v) {
+        if ((v.tag == Value::TAG_STRING || v.tag == Value::TAG_DECIMAL ||
+             v.tag == Value::TAG_BYTES || v.tag == Value::TAG_JSON) &&
+            v.str_val.ptr && v.str_val.len > 0) {
+            char* p = static_cast<char*>(arena_.allocate(v.str_val.len));
+            std::memcpy(p, v.str_val.ptr, v.str_val.len);
+            Value out = v;
+            out.str_val = sql_parser::StringRef{p, v.str_val.len};
+            return out;
+        }
+        return v;
+    }
+
+    Row copy_row_arena(const Row& src) {
+        Row dst = make_row(arena_, src.column_count);
+        for (uint16_t i = 0; i < src.column_count; ++i)
+            dst.set(i, copy_value_arena(src.get(i)));
+        return dst;
+    }
+
+    bool route_row_keys(const TableInfo* table, const Row& row, size_t& idx) const {
+        const auto& keys = shards_.get_shard_keys(table->table_name);
+        if (keys.empty()) return false;
+        std::vector<ShardKeyPart> parts;
+        parts.reserve(keys.size());
+        for (const auto& k : keys) {
+            sql_parser::StringRef kn{k.c_str(), static_cast<uint32_t>(k.size())};
+            const ColumnInfo* col = catalog_.get_column(table, kn);
+            if (!col || col->ordinal >= row.column_count) return false;
+            Value v = row.get(col->ordinal);
+            if (!value_is_routable(v)) return false;
+            parts.push_back(value_to_part(v));
+        }
+        return shards_.try_shard_index_for_parts(
+            table->table_name, parts.data(), parts.size(), idx);
+    }
+
+    Row apply_update_set(const Row& src, const TableInfo* table,
+                         const sql_parser::AstNode** set_cols,
+                         const sql_parser::AstNode** set_exprs,
+                         uint16_t set_count) {
+        Row dst = copy_row_arena(src);
+        auto resolve = make_resolver(catalog_, table, src.values);
+        for (uint16_t i = 0; i < set_count; ++i) {
+            if (!set_cols[i]) continue;
+            const ColumnInfo* col = catalog_.get_column(table, set_cols[i]->value());
+            if (!col) continue;
+            Value nv = value_null();
+            if (functions_) {
+                nv = evaluate_expression<D>(set_exprs[i], resolve, *functions_, arena_);
+            } else {
+                nv = evaluate_shard_key_value(set_exprs[i]);
+            }
+            dst.set(col->ordinal, copy_value_arena(nv));
+        }
+        return dst;
+    }
+
+    sql_parser::StringRef build_identity_pred(const TableInfo* table, const Row& row,
+                                              sql_parser::StringBuilder& sb) {
+        for (uint16_t i = 0; i < table->column_count && i < row.column_count; ++i) {
+            if (i > 0) sb.append(" AND ");
+            sb.append(table->columns[i].name.ptr, table->columns[i].name.len);
+            if (row.get(i).is_null()) {
+                sb.append(" IS NULL", 8);
+            } else {
+                sb.append(" = ");
+                emit_value(row.get(i), sb);
+            }
+        }
+        return sb.finish();
+    }
+
+    sql_parser::StringRef build_delete_identity(const TableInfo* table, const Row& row) {
+        sql_parser::StringBuilder sb(arena_, 256);
+        sb.append("DELETE FROM ");
+        sb.append(table->table_name.ptr, table->table_name.len);
+        sb.append(" WHERE ");
+        return build_identity_pred(table, row, sb);
+    }
+
+    sql_parser::StringRef build_update_identity(const TableInfo* table,
+                                                const sql_parser::AstNode** set_cols,
+                                                const sql_parser::AstNode** set_exprs,
+                                                uint16_t set_count,
+                                                const Row& old_row) {
+        sql_parser::StringBuilder sb(arena_, 256);
+        sb.append("UPDATE ");
+        sb.append(table->table_name.ptr, table->table_name.len);
+        sb.append(" SET ");
+        for (uint16_t i = 0; i < set_count; ++i) {
+            if (i > 0) sb.append(", ");
+            if (set_cols[i]) {
+                sql_parser::StringRef cn = set_cols[i]->value();
+                sb.append(cn.ptr, cn.len);
+            }
+            sb.append(" = ");
+            if (set_exprs[i]) {
+                sql_parser::Emitter<D> emitter(arena_);
+                emitter.emit(set_exprs[i]);
+                sql_parser::StringRef ev = emitter.result();
+                sb.append(ev.ptr, ev.len);
+            }
+        }
+        sb.append(" WHERE ");
+        return build_identity_pred(table, old_row, sb);
+    }
+
+    PlanNode* distribute_update_move(PlanNode* plan, const TableInfo* table,
+                                     const sql_parser::AstNode* where_expr) {
+        if (!remote_executor_)
+            return fail_dml("cannot UPDATE shard key without a remote executor");
+
+        const auto& up = plan->update_plan;
+        const auto& shard_list = shards_.get_shards(table->table_name);
+        std::vector<ShardInfo> pruned = prune_shards(table, where_expr, shard_list);
+        if (pruned.empty()) return plan;
+
+        struct Move {
+            size_t src = 0;
+            size_t dst = 0;
+            Row old_row{};
+            Row new_row{};
+        };
+        std::vector<Move> moves;
+
+        for (const auto& shard : pruned) {
+            size_t src = 0;
+            for (size_t i = 0; i < shard_list.size(); ++i) {
+                if (shard_list[i].backend_name == shard.backend_name) {
+                    src = i;
+                    break;
+                }
+            }
+            sql_parser::StringRef sql = qb_.build_select(
+                table, where_expr, nullptr, 0, nullptr, 0,
+                nullptr, nullptr, 0, -1, false);
+            ResultSet rs = remote_executor_->execute(shard.backend_name.c_str(), sql);
+            for (const auto& row : rs.rows) {
+                Move m;
+                m.src = src;
+                m.old_row = copy_row_arena(row);
+                m.new_row = apply_update_set(m.old_row, table, up.set_columns,
+                                             up.set_exprs, up.set_count);
+                if (!route_row_keys(table, m.new_row, m.dst))
+                    return fail_dml("cannot UPDATE shard key: new key is not routable");
+                moves.push_back(m);
+            }
+        }
+
+        if (moves.empty()) {
+            sql_parser::StringRef sql = qb_.build_update(
+                table, up.set_columns, up.set_exprs, up.set_count, where_expr);
+            return make_remote_scan(pruned[0].backend_name.c_str(), sql, table);
+        }
+
+        bool any_move = false;
+        for (const auto& m : moves) {
+            if (m.src != m.dst) { any_move = true; break; }
+        }
+        if (!any_move) {
+            if (pruned.size() == 1) {
+                sql_parser::StringRef sql = qb_.build_update(
+                    table, up.set_columns, up.set_exprs, up.set_count, where_expr);
+                return make_remote_scan(pruned[0].backend_name.c_str(), sql, table);
+            }
+            const sql_parser::AstNode* final_where = where_expr;
+            return scatter_dml_to_shards(table, pruned, [&]() {
+                return qb_.build_update(
+                    table, up.set_columns, up.set_exprs, up.set_count, final_where);
+            });
+        }
+
+        PlanNode* current = nullptr;
+        std::unordered_map<size_t, std::vector<Row>> inserts;
+        for (const auto& m : moves) {
+            if (m.src == m.dst) {
+                sql_parser::StringRef sql = build_update_identity(
+                    table, up.set_columns, up.set_exprs, up.set_count, m.old_row);
+                current = append_remote(
+                    current, make_remote_scan(shard_list[m.src].backend_name.c_str(),
+                                              sql, table));
+            } else {
+                current = append_remote(
+                    current,
+                    make_remote_scan(shard_list[m.src].backend_name.c_str(),
+                                     build_delete_identity(table, m.old_row), table));
+                inserts[m.dst].push_back(m.new_row);
+            }
+        }
+        for (auto& kv : inserts) {
+            current = append_remote(
+                current,
+                make_remote_scan(shard_list[kv.first].backend_name.c_str(),
+                                 build_insert_from_rows(table, nullptr, 0, kv.second),
+                                 table));
+        }
+        return current ? current : plan;
     }
 
     bool is_column_ref(const sql_parser::AstNode* node, sql_parser::StringRef col_name) const {
@@ -1834,7 +2234,8 @@ private:
         }
 
         // Determine target shards for each row
-        if (!shards_.has_table(table->table_name)) return plan;
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
 
         if (!shards_.is_sharded(table->table_name)) {
             // Unsharded: build a single INSERT with all rows
@@ -1843,42 +2244,37 @@ private:
             return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
         }
 
-        // Sharded: group rows by shard key
-        sql_parser::StringRef shard_key = shards_.get_shard_key(table->table_name);
-        if (!shard_key.ptr) return plan;
+        const auto& key_names = shards_.get_shard_keys(table->table_name);
+        if (key_names.empty()) return plan;
 
-        // Find shard key column ordinal in the result set
-        int shard_col_idx = -1;
-        if (ip.columns && ip.column_count > 0) {
-            for (uint16_t i = 0; i < ip.column_count; ++i) {
-                if (ip.columns[i] && ip.columns[i]->value().equals_ci(shard_key.ptr, shard_key.len)) {
-                    shard_col_idx = static_cast<int>(i);
-                    break;
-                }
-            }
-        } else if (table) {
-            for (uint16_t i = 0; i < table->column_count; ++i) {
-                if (table->columns[i].name.equals_ci(shard_key.ptr, shard_key.len)) {
-                    shard_col_idx = static_cast<int>(i);
-                    break;
-                }
-            }
+        std::vector<int> key_ords(key_names.size(), -1);
+        for (size_t k = 0; k < key_names.size(); ++k) {
+            sql_parser::StringRef kn{key_names[k].c_str(),
+                static_cast<uint32_t>(key_names[k].size())};
+            key_ords[k] = find_insert_key_ordinal(ip.columns, ip.column_count, table, kn);
         }
-
-        if (shard_col_idx < 0) {
-            return fail_dml("cannot route INSERT ... SELECT: shard key column is not present");
+        for (int ord : key_ords) {
+            if (ord < 0)
+                return fail_dml("cannot route INSERT ... SELECT: shard key column is not present");
         }
 
         const auto& shard_list = shards_.get_shards(table->table_name);
 
         std::unordered_map<size_t, std::vector<size_t>> shard_rows;
         for (size_t ri = 0; ri < rs.rows.size(); ++ri) {
-            if (shard_col_idx >= rs.rows[ri].column_count) {
-                return fail_dml("cannot route INSERT ... SELECT: missing shard key value");
+            std::vector<ShardKeyPart> parts;
+            parts.reserve(key_ords.size());
+            for (int ord : key_ords) {
+                if (ord >= rs.rows[ri].column_count)
+                    return fail_dml("cannot route INSERT ... SELECT: missing shard key value");
+                Value v = rs.rows[ri].get(static_cast<uint16_t>(ord));
+                if (!value_is_routable(v))
+                    return fail_dml("cannot route INSERT ... SELECT: shard key is not a literal");
+                parts.push_back(value_to_part(v));
             }
-            Value v = rs.rows[ri].get(static_cast<uint16_t>(shard_col_idx));
             size_t shard_idx = 0;
-            if (!route_value(table->table_name, v, shard_idx)) {
+            if (!shards_.try_shard_index_for_parts(table->table_name, parts.data(),
+                                                   parts.size(), shard_idx)) {
                 return fail_dml("cannot route INSERT ... SELECT: shard key is not a literal");
             }
             shard_rows[shard_idx].push_back(ri);
@@ -2008,17 +2404,13 @@ private:
         }
 
         const TableInfo* table = ctx.scan->scan.table;
-        if (!shards_.has_table(table->table_name) || !shards_.is_sharded(table->table_name)) {
-            if (shards_.has_table(table->table_name) && !shards_.is_sharded(table->table_name)) {
-                // Unsharded: push DISTINCT to remote
-                sql_parser::StringRef sql = qb_.build_select(
-                    table, ctx.where_expr, proj_exprs, proj_count,
-                    nullptr, 0, nullptr, nullptr, 0, -1, true);
-                return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
-            }
-            PlanNode* result = make_plan_node(arena_, PlanNodeType::DISTINCT);
-            result->left = distribute_node(distinct_node->left);
-            return result;
+        if (!shards_.has_table(table->table_name))
+            return fail_dml("table not in shard map");
+        if (!shards_.is_sharded(table->table_name)) {
+            sql_parser::StringRef sql = qb_.build_select(
+                table, ctx.where_expr, proj_exprs, proj_count,
+                nullptr, 0, nullptr, nullptr, 0, -1, true);
+            return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
         }
 
         // Sharded DISTINCT: each shard computes DISTINCT, local DISTINCT deduplicates

--- a/include/sql_engine/distributed_planner.h
+++ b/include/sql_engine/distributed_planner.h
@@ -29,13 +29,15 @@ class DistributedPlanner {
 public:
     DistributedPlanner(const ShardMap& shards, const Catalog& catalog, sql_parser::Arena& arena)
         : shards_(shards), catalog_(catalog), arena_(arena), qb_(arena),
-          remote_executor_(nullptr), functions_(nullptr) {}
+          remote_executor_(nullptr), functions_(nullptr), error_(nullptr) {}
 
     // Extended constructor with remote executor for cross-shard subquery support
     DistributedPlanner(const ShardMap& shards, const Catalog& catalog, sql_parser::Arena& arena,
                        RemoteExecutor* remote_executor, FunctionRegistry<D>* functions)
         : shards_(shards), catalog_(catalog), arena_(arena), qb_(arena),
-          remote_executor_(remote_executor), functions_(functions) {}
+          remote_executor_(remote_executor), functions_(functions), error_(nullptr) {}
+
+    const char* last_error() const { return error_; }
 
     // Rewrite a logical plan for distributed execution.
     // Returns a new plan tree with RemoteScan/MergeAggregate/MergeSort nodes.
@@ -48,6 +50,7 @@ public:
     // Returns a new plan tree with REMOTE_SCAN nodes (for DML, the remote
     // scan carries the DML SQL; the executor calls execute_dml on it).
     PlanNode* distribute_dml(PlanNode* plan) {
+        error_ = nullptr;
         if (!plan) return nullptr;
 
         switch (plan->type) {
@@ -69,6 +72,12 @@ private:
     RemoteQueryBuilder<D> qb_;
     RemoteExecutor* remote_executor_;
     FunctionRegistry<D>* functions_;
+    const char* error_;
+
+    PlanNode* fail_dml(const char* message) {
+        error_ = message;
+        return nullptr;
+    }
 
     // Push aggregate expressions from PROJECT into AGGREGATE node
     // (same logic as PlanExecutor::preprocess_aggregates)
@@ -952,47 +961,29 @@ private:
         }
 
         if (shard_col_idx < 0) {
-            // Can't determine shard -- send to all (scatter)
-            // For INSERT, this is an error in practice. Fall back to first shard.
-            sql_parser::StringRef sql = qb_.build_insert(
-                table, ip.columns, ip.column_count, ip.value_rows, ip.row_count);
-            return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
+            return fail_dml("cannot route INSERT: shard key column is not present");
         }
 
         const auto& shard_list = shards_.get_shards(table->table_name);
 
-        // Group rows by shard: evaluate the shard key value in each row,
-        // hash to determine target shard
-        // Map: shard_index -> list of row indices
+        // Group rows by ShardMap route. Map: shard_index -> list of row indices.
         std::unordered_map<size_t, std::vector<uint16_t>> shard_rows;
-        auto null_resolve = [](sql_parser::StringRef) -> Value { return value_null(); };
 
         for (uint16_t ri = 0; ri < ip.row_count; ++ri) {
             const sql_parser::AstNode* row_ast = ip.value_rows[ri];
             if (!row_ast) continue;
 
-            // Get the shard key value expression (nth child of the row)
             const sql_parser::AstNode* expr = row_ast->first_child;
             for (int j = 0; j < shard_col_idx && expr; ++j) {
                 expr = expr->next_sibling;
             }
+            if (!expr) {
+                return fail_dml("cannot route INSERT: missing shard key value");
+            }
 
-            // Evaluate to get the value, then hash to determine shard
             size_t shard_idx = 0;
-            if (expr) {
-                // Simple hashing: convert to int64 and mod by shard count
-                Value v = evaluate_shard_key_value(expr);
-                if (v.tag == Value::TAG_INT64) {
-                    shard_idx = static_cast<size_t>(
-                        std::abs(v.int_val) % static_cast<int64_t>(shard_list.size()));
-                } else if (v.tag == Value::TAG_STRING && v.str_val.ptr) {
-                    // Simple string hash
-                    uint64_t h = 0;
-                    for (uint32_t k = 0; k < v.str_val.len; ++k) {
-                        h = h * 31 + static_cast<uint8_t>(v.str_val.ptr[k]);
-                    }
-                    shard_idx = static_cast<size_t>(h % shard_list.size());
-                }
+            if (!route_value(table->table_name, evaluate_shard_key_value(expr), shard_idx)) {
+                return fail_dml("cannot route INSERT: shard key is not a literal");
             }
             shard_rows[shard_idx].push_back(ri);
         }
@@ -1066,22 +1057,21 @@ private:
             return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
         }
 
-        // Sharded: check if WHERE references the shard key
         sql_parser::StringRef shard_key = shards_.get_shard_key(table->table_name);
-        const auto& shard_list = shards_.get_shards(table->table_name);
-
-        int target_shard = find_shard_from_where(where_expr, shard_key, shard_list.size());
-
-        if (target_shard >= 0) {
-            // Route to specific shard
-            sql_parser::StringRef sql = qb_.build_update(
-                table, up.set_columns, up.set_exprs, up.set_count, where_expr);
-            return make_remote_scan(shard_list[target_shard].backend_name.c_str(), sql, table);
+        if (assigns_shard_key(up.set_columns, up.set_count, shard_key)) {
+            return fail_dml("cannot UPDATE shard key column");
         }
 
-        // Scatter to all shards
+        const auto& shard_list = shards_.get_shards(table->table_name);
+        std::vector<ShardInfo> pruned = prune_shards(table, where_expr, shard_list);
+        if (pruned.size() == 1) {
+            sql_parser::StringRef sql = qb_.build_update(
+                table, up.set_columns, up.set_exprs, up.set_count, where_expr);
+            return make_remote_scan(pruned[0].backend_name.c_str(), sql, table);
+        }
+
         const sql_parser::AstNode* final_where = where_expr;
-        return scatter_dml_to_shards(table, shard_list, [&]() {
+        return scatter_dml_to_shards(table, pruned, [&]() {
             return qb_.build_update(
                 table, up.set_columns, up.set_exprs, up.set_count, final_where);
         });
@@ -1114,100 +1104,72 @@ private:
             return make_remote_scan(shards_.get_backend(table->table_name), sql, table);
         }
 
-        // Sharded: check if WHERE references the shard key
-        sql_parser::StringRef shard_key = shards_.get_shard_key(table->table_name);
         const auto& shard_list = shards_.get_shards(table->table_name);
-
-        int target_shard = find_shard_from_where(where_expr, shard_key, shard_list.size());
-
-        if (target_shard >= 0) {
-            // Route to specific shard
+        std::vector<ShardInfo> pruned = prune_shards(table, where_expr, shard_list);
+        if (pruned.size() == 1) {
             sql_parser::StringRef sql = qb_.build_delete(table, where_expr);
-            return make_remote_scan(shard_list[target_shard].backend_name.c_str(), sql, table);
+            return make_remote_scan(pruned[0].backend_name.c_str(), sql, table);
         }
 
-        // Scatter to all shards
         const sql_parser::AstNode* final_where = where_expr;
-        return scatter_dml_to_shards(table, shard_list, [&]() {
+        return scatter_dml_to_shards(table, pruned, [&]() {
             return qb_.build_delete(table, final_where);
         });
     }
 
-    // Evaluate a shard key expression from a VALUES row (simple: literal values only)
     Value evaluate_shard_key_value(const sql_parser::AstNode* expr) {
         if (!expr) return value_null();
         if (expr->type == sql_parser::NodeType::NODE_LITERAL_INT) {
             sql_parser::StringRef val = expr->value();
-            int64_t n = 0;
-            for (uint32_t i = 0; i < val.len; ++i) {
-                char c = val.ptr[i];
-                if (c >= '0' && c <= '9') n = n * 10 + (c - '0');
-            }
-            return value_int(n);
+            if (!val.ptr || val.len == 0) return value_null();
+            return value_int(std::strtoll(val.ptr, nullptr, 10));
+        }
+        if (expr->type == sql_parser::NodeType::NODE_LITERAL_FLOAT) {
+            sql_parser::StringRef val = expr->value();
+            double dv = val.ptr ? std::strtod(val.ptr, nullptr) : 0.0;
+            return value_int(static_cast<int64_t>(dv));
         }
         if (expr->type == sql_parser::NodeType::NODE_LITERAL_STRING) {
             return value_string(expr->value());
         }
+        if (expr->type == sql_parser::NodeType::NODE_UNARY_OP) {
+            sql_parser::StringRef op = expr->value();
+            if (op.len == 1 && op.ptr[0] == '-') {
+                Value inner = evaluate_shard_key_value(expr->first_child);
+                if (inner.tag == Value::TAG_INT64) return value_int(-inner.int_val);
+            }
+        }
         return value_null();
     }
 
-    // Check if a WHERE expression contains shard_key = <literal>.
-    // Returns the target shard index, or -1 if not determinable.
-    int find_shard_from_where(const sql_parser::AstNode* where_expr,
-                               sql_parser::StringRef shard_key,
-                               size_t shard_count) {
-        if (!where_expr || !shard_key.ptr || shard_count == 0) return -1;
-
-        // Look for binary_op '=' with one side being the shard key column
-        if (where_expr->type == sql_parser::NodeType::NODE_BINARY_OP) {
-            sql_parser::StringRef op = where_expr->value();
-            if (op.len == 1 && op.ptr[0] == '=') {
-                const sql_parser::AstNode* left = where_expr->first_child;
-                const sql_parser::AstNode* right = left ? left->next_sibling : nullptr;
-                if (!left || !right) return -1;
-
-                // Check if left is the shard key column and right is a literal (or vice versa)
-                const sql_parser::AstNode* col_node = nullptr;
-                const sql_parser::AstNode* val_node = nullptr;
-
-                if (is_column_ref(left, shard_key)) {
-                    col_node = left;
-                    val_node = right;
-                } else if (is_column_ref(right, shard_key)) {
-                    col_node = right;
-                    val_node = left;
-                }
-
-                if (col_node && val_node) {
-                    Value v = evaluate_shard_key_value(val_node);
-                    if (v.tag == Value::TAG_INT64) {
-                        return static_cast<int>(
-                            std::abs(v.int_val) % static_cast<int64_t>(shard_count));
-                    }
-                    if (v.tag == Value::TAG_STRING && v.str_val.ptr) {
-                        uint64_t h = 0;
-                        for (uint32_t k = 0; k < v.str_val.len; ++k) {
-                            h = h * 31 + static_cast<uint8_t>(v.str_val.ptr[k]);
-                        }
-                        return static_cast<int>(h % shard_count);
-                    }
-                }
-            }
-
-            // Check AND: both sides might contain the shard key
-            if (op.equals_ci("AND", 3)) {
-                const sql_parser::AstNode* left = where_expr->first_child;
-                const sql_parser::AstNode* right = left ? left->next_sibling : nullptr;
-                int r = find_shard_from_where(left, shard_key, shard_count);
-                if (r >= 0) return r;
-                return find_shard_from_where(right, shard_key, shard_count);
-            }
+    bool route_value(sql_parser::StringRef table_name, const Value& v, size_t& shard_idx) const {
+        if (v.tag == Value::TAG_INT64) {
+            shard_idx = shards_.shard_index_for_int(table_name, v.int_val);
+            return true;
         }
-
-        return -1;
+        if (v.tag == Value::TAG_UINT64) {
+            shard_idx = shards_.shard_index_for_int(
+                table_name, static_cast<int64_t>(v.uint_val));
+            return true;
+        }
+        if (v.tag == Value::TAG_STRING && v.str_val.ptr) {
+            shard_idx = shards_.shard_index_for_string(
+                table_name, v.str_val.ptr, v.str_val.len);
+            return true;
+        }
+        return false;
     }
 
-    bool is_column_ref(const sql_parser::AstNode* node, sql_parser::StringRef col_name) {
+    bool assigns_shard_key(const sql_parser::AstNode** set_columns, uint16_t set_count,
+                           sql_parser::StringRef shard_key) const {
+        if (!set_columns || !shard_key.ptr) return false;
+        for (uint16_t i = 0; i < set_count; ++i) {
+            if (is_column_ref(set_columns[i], shard_key)) return true;
+        }
+        return false;
+    }
+
+    bool is_column_ref(const sql_parser::AstNode* node, sql_parser::StringRef col_name) const {
         if (!node) return false;
         if (node->type == sql_parser::NodeType::NODE_COLUMN_REF ||
             node->type == sql_parser::NodeType::NODE_IDENTIFIER) {
@@ -1572,24 +1534,21 @@ private:
             }
         }
 
+        if (shard_col_idx < 0) {
+            return fail_dml("cannot route INSERT ... SELECT: shard key column is not present");
+        }
+
         const auto& shard_list = shards_.get_shards(table->table_name);
 
-        // Group rows by shard
         std::unordered_map<size_t, std::vector<size_t>> shard_rows;
         for (size_t ri = 0; ri < rs.rows.size(); ++ri) {
+            if (shard_col_idx >= rs.rows[ri].column_count) {
+                return fail_dml("cannot route INSERT ... SELECT: missing shard key value");
+            }
+            Value v = rs.rows[ri].get(static_cast<uint16_t>(shard_col_idx));
             size_t shard_idx = 0;
-            if (shard_col_idx >= 0 && shard_col_idx < rs.rows[ri].column_count) {
-                Value v = rs.rows[ri].get(static_cast<uint16_t>(shard_col_idx));
-                if (v.tag == Value::TAG_INT64) {
-                    shard_idx = static_cast<size_t>(
-                        std::abs(v.int_val) % static_cast<int64_t>(shard_list.size()));
-                } else if (v.tag == Value::TAG_STRING && v.str_val.ptr) {
-                    uint64_t h = 0;
-                    for (uint32_t k = 0; k < v.str_val.len; ++k) {
-                        h = h * 31 + static_cast<uint8_t>(v.str_val.ptr[k]);
-                    }
-                    shard_idx = static_cast<size_t>(h % shard_list.size());
-                }
+            if (!route_value(table->table_name, v, shard_idx)) {
+                return fail_dml("cannot route INSERT ... SELECT: shard key is not a literal");
             }
             shard_rows[shard_idx].push_back(ri);
         }

--- a/include/sql_engine/distributed_txn.h
+++ b/include/sql_engine/distributed_txn.h
@@ -178,6 +178,18 @@ public:
         return executor_.execute_dml(backend_name, sql);
     }
 
+    ResultSet route_query(const char* backend_name,
+                          sql_parser::StringRef sql) override {
+        if (!active_) return executor_.execute(backend_name, sql);
+        auto it = sessions_.find(backend_name);
+        if (it != sessions_.end() && it->second) {
+            return it->second->execute(sql);
+        }
+        return executor_.execute(backend_name, sql);
+    }
+
+    bool route_query_supported() const override { return true; }
+
     bool commit() override {
         if (!active_) return false;
         if (participants_.empty()) {

--- a/include/sql_engine/operators/aggregate_op.h
+++ b/include/sql_engine/operators/aggregate_op.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <cstring>
 #include <cmath>
+#include <unordered_set>
+#include "sql_parser/common.h"
 
 namespace sql_engine {
 
@@ -131,6 +133,8 @@ private:
         Value max_val{};
         bool has_value = false;
         bool count_star = false; // COUNT(*)
+        bool distinct = false;
+        std::unordered_set<std::string> seen;
     };
 
     struct GroupState {
@@ -186,9 +190,9 @@ private:
 
         if (expr->type == sql_parser::NodeType::NODE_FUNCTION_CALL) {
             sql_parser::StringRef name = expr->value();
+            state.distinct = (expr->flags & sql_parser::FLAG_FUNC_DISTINCT) != 0;
             if (name.equals_ci("COUNT", 5)) {
                 state.type = AggType::COUNT;
-                // Check for COUNT(*)
                 const sql_parser::AstNode* arg = expr->first_child;
                 if (arg && arg->type == sql_parser::NodeType::NODE_ASTERISK) {
                     state.count_star = true;
@@ -203,6 +207,14 @@ private:
         state.type = AggType::EXPR;
     }
 
+    static bool note_distinct(AggState& state, const sql_parser::AstNode* expr,
+                             const Value& v) {
+        bool distinct = state.distinct ||
+            (expr && (expr->flags & sql_parser::FLAG_FUNC_DISTINCT));
+        if (!distinct) return true;
+        return state.seen.insert(value_to_string(v)).second;
+    }
+
     void update_agg(AggState& state, const sql_parser::AstNode* expr,
                     const std::function<Value(sql_parser::StringRef)>& resolver) {
         switch (state.type) {
@@ -210,10 +222,9 @@ private:
                 if (state.count_star) {
                     state.count++;
                 } else {
-                    // COUNT(expr) - count non-null values
                     const sql_parser::AstNode* arg = expr->first_child;
                     Value v = evaluate_expression<D>(arg, resolver, functions_, arena_);
-                    if (!v.is_null()) state.count++;
+                    if (!v.is_null() && note_distinct(state, expr, v)) state.count++;
                 }
                 break;
             }
@@ -221,7 +232,7 @@ private:
             case AggType::AVG: {
                 const sql_parser::AstNode* arg = expr->first_child;
                 Value v = evaluate_expression<D>(arg, resolver, functions_, arena_);
-                if (!v.is_null()) {
+                if (!v.is_null() && note_distinct(state, expr, v)) {
                     state.sum += v.to_double();
                     state.count++;
                     state.has_value = true;
@@ -231,7 +242,7 @@ private:
             case AggType::MIN: {
                 const sql_parser::AstNode* arg = expr->first_child;
                 Value v = evaluate_expression<D>(arg, resolver, functions_, arena_);
-                if (!v.is_null()) {
+                if (!v.is_null() && note_distinct(state, expr, v)) {
                     if (!state.has_value || compare_values(v, state.min_val) < 0) {
                         state.min_val = v;
                         state.has_value = true;
@@ -242,7 +253,7 @@ private:
             case AggType::MAX: {
                 const sql_parser::AstNode* arg = expr->first_child;
                 Value v = evaluate_expression<D>(arg, resolver, functions_, arena_);
-                if (!v.is_null()) {
+                if (!v.is_null() && note_distinct(state, expr, v)) {
                     if (!state.has_value || compare_values(v, state.max_val) > 0) {
                         state.max_val = v;
                         state.has_value = true;

--- a/include/sql_engine/operators/set_op_op.h
+++ b/include/sql_engine/operators/set_op_op.h
@@ -17,86 +17,82 @@ class SetOpOperator : public Operator {
 public:
     SetOpOperator(Operator* left, Operator* right, uint8_t op, bool all,
                   bool parallel_open = false, ThreadPool* pool = nullptr)
-        : left_(left), right_(right), op_(op), all_(all),
+        : op_(op), all_(all), parallel_open_(parallel_open), pool_(pool) {
+        children_.push_back(left);
+        children_.push_back(right);
+    }
+
+    explicit SetOpOperator(std::vector<Operator*> children,
+                           bool parallel_open = false, ThreadPool* pool = nullptr)
+        : children_(std::move(children)), op_(SET_OP_UNION), all_(true),
           parallel_open_(parallel_open), pool_(pool) {}
 
     void open() override {
-        if (parallel_open_ && pool_) {
-            // Thread-pool parallel open: ~1-2us dispatch vs ~200us for std::async
-            auto fl = pool_->submit([this]{ left_->open(); });
-            auto fr = pool_->submit([this]{ right_->open(); });
-            fl.get();
-            fr.get();
-        } else if (parallel_open_) {
-            // Fallback: std::async when no pool available
-            auto fl = std::async(std::launch::async, [this]{ left_->open(); });
-            auto fr = std::async(std::launch::async, [this]{ right_->open(); });
-            fl.get();
-            fr.get();
+        if (children_.empty()) return;
+        if (parallel_open_ && children_.size() > 1) {
+            std::vector<std::future<void>> futures;
+            futures.reserve(children_.size());
+            for (size_t i = 0; i < children_.size(); ++i) {
+                auto launcher = [this, i]{ children_[i]->open(); };
+                if (pool_) {
+                    futures.push_back(pool_->submit(std::move(launcher)));
+                } else {
+                    futures.push_back(std::async(std::launch::async, std::move(launcher)));
+                }
+            }
+            for (auto& f : futures) f.get();
         } else {
-            left_->open();
-            right_->open();
+            for (auto* c : children_) c->open();
         }
-        reading_left_ = true;
+        child_idx_ = 0;
         seen_.clear();
         expected_col_count_ = -1;
 
-        if (op_ == SET_OP_INTERSECT || op_ == SET_OP_EXCEPT) {
-            // Materialize right side into a set
+        if ((op_ == SET_OP_INTERSECT || op_ == SET_OP_EXCEPT) && children_.size() >= 2) {
             right_set_.clear();
             Row r{};
-            while (right_->next(r)) {
+            while (children_[1]->next(r)) {
                 check_col_count(r);
                 check_operator_row_limit(right_set_.size(), kDefaultMaxOperatorRows, "SetOpOperator");
                 right_set_.insert(row_key(r));
             }
-            right_->close();
+            children_[1]->close();
+            right_closed_ = true;
         }
     }
 
     bool next(Row& out) override {
+        if (children_.empty()) return false;
+
         if (op_ == SET_OP_UNION && !all_) {
-            // UNION (deduplicated)
-            while (true) {
-                bool got = false;
-                if (reading_left_) {
-                    got = left_->next(out);
-                    if (!got) { reading_left_ = false; }
+            while (child_idx_ < children_.size()) {
+                if (!children_[child_idx_]->next(out)) {
+                    ++child_idx_;
+                    continue;
                 }
-                if (!reading_left_) {
-                    got = right_->next(out);
-                    if (!got) return false;
+                check_col_count(out);
+                std::string key = row_key(out);
+                if (seen_.find(key) == seen_.end()) {
+                    check_operator_row_limit(seen_.size(), kDefaultMaxOperatorRows, "SetOpOperator");
                 }
-                if (got) {
-                    check_col_count(out);
-                    std::string key = row_key(out);
-                    if (seen_.find(key) == seen_.end()) {
-                        check_operator_row_limit(seen_.size(), kDefaultMaxOperatorRows, "SetOpOperator");
-                    }
-                    if (seen_.insert(key).second) return true;
-                }
+                if (seen_.insert(key).second) return true;
             }
+            return false;
         }
 
         if (op_ == SET_OP_UNION && all_) {
-            // UNION ALL: yield left then right
-            if (reading_left_) {
-                if (left_->next(out)) {
+            while (child_idx_ < children_.size()) {
+                if (children_[child_idx_]->next(out)) {
                     check_col_count(out);
                     return true;
                 }
-                reading_left_ = false;
-            }
-            if (right_->next(out)) {
-                check_col_count(out);
-                return true;
+                ++child_idx_;
             }
             return false;
         }
 
         if (op_ == SET_OP_INTERSECT) {
-            // Yield left rows that also appear in right
-            while (left_->next(out)) {
+            while (children_[0]->next(out)) {
                 check_col_count(out);
                 std::string key = row_key(out);
                 if (right_set_.count(key)) {
@@ -108,8 +104,7 @@ public:
         }
 
         if (op_ == SET_OP_EXCEPT) {
-            // Yield left rows that don't appear in right
-            while (left_->next(out)) {
+            while (children_[0]->next(out)) {
                 check_col_count(out);
                 std::string key = row_key(out);
                 if (!right_set_.count(key)) {
@@ -124,20 +119,22 @@ public:
     }
 
     void close() override {
-        left_->close();
-        right_->close();
+        for (size_t i = 0; i < children_.size(); ++i) {
+            if (right_closed_ && i == 1) continue;
+            children_[i]->close();
+        }
         seen_.clear();
         right_set_.clear();
     }
 
 private:
-    Operator* left_;
-    Operator* right_;
+    std::vector<Operator*> children_;
     uint8_t op_;
     bool all_;
     bool parallel_open_;
     ThreadPool* pool_ = nullptr;
-    bool reading_left_ = true;
+    size_t child_idx_ = 0;
+    bool right_closed_ = false;
     std::unordered_set<std::string> seen_;
     std::unordered_set<std::string> right_set_;
     // Column count established by the first row we see. Used to detect

--- a/include/sql_engine/pg_connection_pool.h
+++ b/include/sql_engine/pg_connection_pool.h
@@ -1,0 +1,108 @@
+#ifndef SQL_ENGINE_PG_CONNECTION_POOL_H
+#define SQL_ENGINE_PG_CONNECTION_POOL_H
+
+#include "sql_engine/backend_config.h"
+#include <libpq-fe.h>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include <memory>
+
+#ifndef SQL_ENGINE_PG_STATEMENT_TIMEOUT_MS
+#define SQL_ENGINE_PG_STATEMENT_TIMEOUT_MS 30000
+#endif
+
+namespace sql_engine {
+
+class PgConnectionPool {
+public:
+    PgConnectionPool() = default;
+
+    ~PgConnectionPool() {
+        for (auto& kv : backends_) {
+            auto& be = *kv.second;
+            std::lock_guard<std::mutex> lk(be.mu);
+            for (PGconn* c : be.idle) {
+                if (c) PQfinish(c);
+            }
+        }
+    }
+
+    void add_backend(const BackendConfig& config) {
+        auto be = std::make_unique<Backend>();
+        be->config = config;
+        backends_[config.name] = std::move(be);
+    }
+
+    bool has_backend(const std::string& name) const {
+        return backends_.find(name) != backends_.end();
+    }
+
+    PGconn* checkout(const std::string& backend) {
+        Backend& be = get_backend(backend);
+        {
+            std::lock_guard<std::mutex> lk(be.mu);
+            if (!be.idle.empty()) {
+                PGconn* c = be.idle.back();
+                be.idle.pop_back();
+                if (c && PQstatus(c) == CONNECTION_OK) return c;
+                if (c) PQfinish(c);
+            }
+        }
+        return create_connection(be);
+    }
+
+    void checkin(const std::string& backend, PGconn* conn) {
+        if (!conn) return;
+        Backend& be = get_backend(backend);
+        std::lock_guard<std::mutex> lk(be.mu);
+        be.idle.push_back(conn);
+    }
+
+private:
+    struct Backend {
+        BackendConfig config;
+        std::mutex mu;
+        std::vector<PGconn*> idle;
+    };
+
+    std::unordered_map<std::string, std::unique_ptr<Backend>> backends_;
+
+    Backend& get_backend(const std::string& name) {
+        auto it = backends_.find(name);
+        if (it == backends_.end()) {
+            throw std::runtime_error("PgConnectionPool: unknown backend: " + name);
+        }
+        return *it->second;
+    }
+
+    static PGconn* create_connection(Backend& be) {
+        const BackendConfig& cfg = be.config;
+        std::string conninfo = "host=" + cfg.host
+            + " port=" + std::to_string(cfg.port)
+            + " user=" + cfg.user
+            + " password=" + cfg.password
+            + " dbname=" + cfg.database
+            + " connect_timeout=5"
+            + " options='-c statement_timeout="
+                + std::to_string(SQL_ENGINE_PG_STATEMENT_TIMEOUT_MS) + "'";
+        if (!cfg.ssl_mode.empty()) conninfo += " sslmode=" + cfg.ssl_mode;
+        if (!cfg.ssl_ca.empty()) conninfo += " sslrootcert=" + cfg.ssl_ca;
+        if (!cfg.ssl_cert.empty()) conninfo += " sslcert=" + cfg.ssl_cert;
+        if (!cfg.ssl_key.empty()) conninfo += " sslkey=" + cfg.ssl_key;
+
+        PGconn* c = PQconnectdb(conninfo.c_str());
+        if (PQstatus(c) != CONNECTION_OK) {
+            std::string err = PQerrorMessage(c);
+            PQfinish(c);
+            throw std::runtime_error("PgConnectionPool connect failed for " + cfg.name + ": " + err);
+        }
+        return c;
+    }
+};
+
+} // namespace sql_engine
+
+#endif

--- a/include/sql_engine/plan_builder.h
+++ b/include/sql_engine/plan_builder.h
@@ -25,6 +25,7 @@
 #include "sql_parser/common.h"
 #include "sql_parser/arena.h"
 #include <cstring>
+#include <cstdlib>
 #include <vector>
 
 namespace sql_engine {
@@ -114,6 +115,55 @@ private:
             if (item->first_child && is_window_function(item->first_child)) return true;
         }
         return false;
+    }
+
+    static const sql_parser::AstNode* select_item_expr(const sql_parser::AstNode* item) {
+        return item ? item->first_child : nullptr;
+    }
+
+    static sql_parser::StringRef select_item_alias(const sql_parser::AstNode* item) {
+        if (!item) return {};
+        for (const sql_parser::AstNode* c = item->first_child; c; c = c->next_sibling) {
+            if (c->type == sql_parser::NodeType::NODE_ALIAS) return c->value();
+        }
+        return {};
+    }
+
+    static const sql_parser::AstNode* resolve_order_key(
+            const sql_parser::AstNode* key, const sql_parser::AstNode* select_items) {
+        if (!key || !select_items) return key;
+        uint16_t n = count_children(select_items);
+        if (n == 0) return key;
+
+        if (key->type == sql_parser::NodeType::NODE_LITERAL_INT) {
+            sql_parser::StringRef sv = key->value();
+            if (!sv.ptr || sv.len == 0) return key;
+            int64_t pos = std::strtoll(sv.ptr, nullptr, 10);
+            if (pos < 1 || pos > static_cast<int64_t>(n)) return key;
+            uint16_t idx = 0;
+            for (const sql_parser::AstNode* item = select_items->first_child; item;
+                 item = item->next_sibling, ++idx) {
+                if (idx + 1 == static_cast<uint16_t>(pos)) {
+                    const sql_parser::AstNode* expr = select_item_expr(item);
+                    return expr ? expr : key;
+                }
+            }
+            return key;
+        }
+
+        if (key->type == sql_parser::NodeType::NODE_COLUMN_REF ||
+            key->type == sql_parser::NodeType::NODE_IDENTIFIER) {
+            sql_parser::StringRef name = key->value();
+            for (const sql_parser::AstNode* item = select_items->first_child; item;
+                 item = item->next_sibling) {
+                sql_parser::StringRef alias = select_item_alias(item);
+                if (alias.ptr && alias.equals_ci(name.ptr, name.len)) {
+                    const sql_parser::AstNode* expr = select_item_expr(item);
+                    return expr ? expr : key;
+                }
+            }
+        }
+        return key;
     }
 
     // Check if an expression (or any descendant) contains an aggregate function call.
@@ -279,10 +329,12 @@ private:
                 arena_.allocate(sizeof(sql_parser::AstNode*) * cnt));
             auto* dirs = static_cast<uint8_t*>(arena_.allocate(cnt));
 
+            const sql_parser::AstNode* select_items =
+                find_child(select_ast, sql_parser::NodeType::NODE_SELECT_ITEM_LIST);
+
             uint16_t idx = 0;
             for (const sql_parser::AstNode* item = order_by->first_child; item; item = item->next_sibling) {
-                // First child is the key expression
-                keys[idx] = item->first_child;
+                keys[idx] = resolve_order_key(item->first_child, select_items);
                 // Check for DESC direction (second child with "DESC" value)
                 dirs[idx] = 0; // ASC by default
                 const sql_parser::AstNode* dir_node = find_child(item, sql_parser::NodeType::NODE_IDENTIFIER);

--- a/include/sql_engine/plan_executor.h
+++ b/include/sql_engine/plan_executor.h
@@ -1171,11 +1171,29 @@ private:
     }
 
     Operator* build_set_op(PlanNode* node) {
+        std::vector<PlanNode*> remote_leaves;
+        if (node->set_op.op == SET_OP_UNION && node->set_op.all &&
+            collect_union_all_remotes(node, remote_leaves) &&
+            remote_leaves.size() > 2) {
+            std::vector<Operator*> children;
+            children.reserve(remote_leaves.size());
+            for (PlanNode* leaf : remote_leaves) {
+                Operator* child = build_remote_scan(leaf);
+                if (!child) return nullptr;
+                children.push_back(child);
+            }
+            bool parallel = parallel_open_enabled_ && children.size() > 1;
+            auto op = std::make_unique<SetOpOperator>(
+                std::move(children), parallel, parallel ? pool_ : nullptr);
+            Operator* ptr = op.get();
+            operators_.push_back(std::move(op));
+            return ptr;
+        }
+
         Operator* left = build_operator(node->left);
         Operator* right = build_operator(node->right);
         if (!left || !right) return nullptr;
 
-        // Enable parallel open when both children are remote scans and executor is thread-safe
         bool parallel = parallel_open_enabled_ &&
                          (node->left && node->left->type == PlanNodeType::REMOTE_SCAN &&
                           node->right && node->right->type == PlanNodeType::REMOTE_SCAN);
@@ -1185,6 +1203,21 @@ private:
         Operator* ptr = op.get();
         operators_.push_back(std::move(op));
         return ptr;
+    }
+
+    static bool collect_union_all_remotes(const PlanNode* node,
+                                          std::vector<PlanNode*>& out) {
+        if (!node) return false;
+        if (node->type == PlanNodeType::REMOTE_SCAN) {
+            out.push_back(const_cast<PlanNode*>(node));
+            return true;
+        }
+        if (node->type == PlanNodeType::SET_OP &&
+            node->set_op.op == SET_OP_UNION && node->set_op.all) {
+            return collect_union_all_remotes(node->left, out) &&
+                   collect_union_all_remotes(node->right, out);
+        }
+        return false;
     }
 
     Operator* build_remote_scan(PlanNode* node) {

--- a/include/sql_engine/plan_executor.h
+++ b/include/sql_engine/plan_executor.h
@@ -57,6 +57,7 @@
 #include <vector>
 #include <memory>
 #include <cstdlib>
+#include <cstring>
 
 namespace sql_engine {
 
@@ -847,15 +848,128 @@ private:
         return ptr;
     }
 
+    static bool same_agg_call(const sql_parser::AstNode* a, const sql_parser::AstNode* b) {
+        if (!a || !b) return false;
+        if (a->type != sql_parser::NodeType::NODE_FUNCTION_CALL ||
+            b->type != sql_parser::NodeType::NODE_FUNCTION_CALL) return false;
+        return a->value().equals_ci(b->value().ptr, b->value().len);
+    }
+
+    const sql_parser::AstNode* rewrite_having_expr(const sql_parser::AstNode* expr,
+                                                    PlanNode* agg_node) {
+        if (!expr || !agg_node) return expr;
+        uint16_t group_count = 0;
+        uint16_t agg_count = 0;
+        const sql_parser::AstNode** agg_exprs = nullptr;
+        const sql_parser::AstNode** group_by = nullptr;
+        if (agg_node->type == PlanNodeType::AGGREGATE) {
+            group_count = agg_node->aggregate.group_count;
+            agg_count = agg_node->aggregate.agg_count;
+            agg_exprs = agg_node->aggregate.agg_exprs;
+            group_by = agg_node->aggregate.group_by;
+        } else if (agg_node->type == PlanNodeType::MERGE_AGGREGATE) {
+            group_count = agg_node->merge_aggregate.group_key_count;
+            if (agg_node->merge_aggregate.output_exprs &&
+                agg_node->merge_aggregate.output_expr_count > group_count) {
+                agg_exprs = agg_node->merge_aggregate.output_exprs + group_count;
+                agg_count = static_cast<uint16_t>(
+                    agg_node->merge_aggregate.output_expr_count - group_count);
+                group_by = agg_node->merge_aggregate.output_exprs;
+            }
+        } else {
+            return expr;
+        }
+
+        if (expr->type == sql_parser::NodeType::NODE_FUNCTION_CALL && agg_exprs) {
+            for (uint16_t i = 0; i < agg_count; ++i) {
+                if (same_agg_call(expr, agg_exprs[i])) {
+                    sql_parser::StringRef name = expr->value();
+                    return sql_parser::make_node(
+                        arena_, sql_parser::NodeType::NODE_IDENTIFIER, name);
+                }
+            }
+        }
+
+        bool changed = false;
+        sql_parser::AstNode* clone = sql_parser::make_node(
+            arena_, expr->type, expr->value(), expr->flags);
+        for (const sql_parser::AstNode* c = expr->first_child; c; c = c->next_sibling) {
+            const sql_parser::AstNode* rw = rewrite_having_expr(c, agg_node);
+            if (rw != c) changed = true;
+            if (rw) clone->add_child(const_cast<sql_parser::AstNode*>(rw));
+        }
+        (void)group_count;
+        (void)group_by;
+        return changed ? clone : expr;
+    }
+
+    const TableInfo* make_agg_output_table(PlanNode* agg_node) {
+        if (!agg_node) return nullptr;
+        uint16_t group_count = 0;
+        uint16_t agg_count = 0;
+        const sql_parser::AstNode** group_by = nullptr;
+        const sql_parser::AstNode** agg_exprs = nullptr;
+        if (agg_node->type == PlanNodeType::AGGREGATE) {
+            group_count = agg_node->aggregate.group_count;
+            agg_count = agg_node->aggregate.agg_count;
+            group_by = agg_node->aggregate.group_by;
+            agg_exprs = agg_node->aggregate.agg_exprs;
+        } else if (agg_node->type == PlanNodeType::MERGE_AGGREGATE &&
+                   agg_node->merge_aggregate.output_exprs) {
+            group_count = agg_node->merge_aggregate.group_key_count;
+            group_by = agg_node->merge_aggregate.output_exprs;
+            if (agg_node->merge_aggregate.output_expr_count > group_count) {
+                agg_exprs = agg_node->merge_aggregate.output_exprs + group_count;
+                agg_count = static_cast<uint16_t>(
+                    agg_node->merge_aggregate.output_expr_count - group_count);
+            }
+        } else {
+            return nullptr;
+        }
+
+        uint16_t n = static_cast<uint16_t>(group_count + agg_count);
+        if (n == 0) return nullptr;
+        auto* cols = static_cast<ColumnInfo*>(arena_.allocate(sizeof(ColumnInfo) * n));
+        if (!cols) return nullptr;
+        for (uint16_t i = 0; i < group_count; ++i) {
+            cols[i].ordinal = i;
+            cols[i].nullable = true;
+            cols[i].type = SqlType::make_int();
+            cols[i].name = (group_by && group_by[i]) ? group_by[i]->value()
+                                                     : sql_parser::StringRef{};
+        }
+        for (uint16_t i = 0; i < agg_count; ++i) {
+            cols[group_count + i].ordinal = static_cast<uint16_t>(group_count + i);
+            cols[group_count + i].nullable = true;
+            cols[group_count + i].type = SqlType::make_int();
+            cols[group_count + i].name = (agg_exprs && agg_exprs[i])
+                ? agg_exprs[i]->value() : sql_parser::StringRef{};
+        }
+        auto* ti = static_cast<TableInfo*>(arena_.allocate(sizeof(TableInfo)));
+        if (!ti) return nullptr;
+        std::memset(ti, 0, sizeof(TableInfo));
+        ti->columns = cols;
+        ti->column_count = n;
+        return ti;
+    }
+
     Operator* build_filter(PlanNode* node) {
         Operator* child = build_operator(node->left);
         if (!child && node->left) return nullptr;
 
         std::vector<const TableInfo*> tables;
-        collect_tables(node->left, tables);
+        const sql_parser::AstNode* expr = node->filter.expr;
+        if (node->left && (node->left->type == PlanNodeType::AGGREGATE ||
+                           node->left->type == PlanNodeType::MERGE_AGGREGATE)) {
+            expr = rewrite_having_expr(expr, node->left);
+            const TableInfo* synth = make_agg_output_table(node->left);
+            if (synth) tables.push_back(synth);
+        } else {
+            collect_tables(node->left, tables);
+        }
 
         auto op = std::make_unique<FilterOperator<D>>(
-            child, node->filter.expr, catalog_, tables, functions_, arena_,
+            child, expr, catalog_, tables, functions_, arena_,
             &subquery_exec_, outer_resolver_);
         Operator* ptr = op.get();
         operators_.push_back(std::move(op));

--- a/include/sql_engine/plan_executor.h
+++ b/include/sql_engine/plan_executor.h
@@ -56,6 +56,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdlib>
 
 namespace sql_engine {
 
@@ -1170,12 +1171,21 @@ private:
 
     uint16_t resolve_column_index(const sql_parser::AstNode* key, const TableInfo* table) {
         if (!key || !table) return 0;
+        if (key->type == sql_parser::NodeType::NODE_LITERAL_INT) {
+            sql_parser::StringRef sv = key->value();
+            if (!sv.ptr || sv.len == 0) return 0;
+            int64_t n = std::strtoll(sv.ptr, nullptr, 10);
+            if (n < 1) return 0;
+            if (n > static_cast<int64_t>(table->column_count)) {
+                return static_cast<uint16_t>(table->column_count - 1);
+            }
+            return static_cast<uint16_t>(n - 1);
+        }
         sql_parser::StringRef col_name;
         if (key->type == sql_parser::NodeType::NODE_COLUMN_REF ||
             key->type == sql_parser::NodeType::NODE_IDENTIFIER) {
             col_name = key->value();
         } else if (key->type == sql_parser::NodeType::NODE_QUALIFIED_NAME) {
-            // table.column -- get the column part
             const sql_parser::AstNode* c = key->first_child;
             if (c && c->next_sibling) col_name = c->next_sibling->value();
             else if (c) col_name = c->value();

--- a/include/sql_engine/plan_node.h
+++ b/include/sql_engine/plan_node.h
@@ -101,7 +101,7 @@ struct PlanNode {
         struct {
             const char* backend_name;
             const char* remote_sql;
-            uint16_t remote_sql_len;
+            uint32_t remote_sql_len;
             const TableInfo* table;       // expected result schema (for SELECT *)
             // Optional projection expressions used to derive result column
             // names when the remote SQL is not a passthrough SELECT *. When

--- a/include/sql_engine/remote_query_builder.h
+++ b/include/sql_engine/remote_query_builder.h
@@ -94,6 +94,28 @@ public:
         return sb.finish();
     }
 
+    sql_parser::StringRef build_select_join(
+            const TableInfo* left,
+            const TableInfo* right,
+            const sql_parser::AstNode* on_expr,
+            const sql_parser::AstNode* where_expr)
+    {
+        sql_parser::StringBuilder sb(arena_, 512);
+        sb.append("SELECT * FROM ");
+        if (left) sb.append(left->table_name.ptr, left->table_name.len);
+        sb.append(" JOIN ");
+        if (right) sb.append(right->table_name.ptr, right->table_name.len);
+        if (on_expr) {
+            sb.append(" ON ");
+            emit_expr(on_expr, sb);
+        }
+        if (where_expr) {
+            sb.append(" WHERE ");
+            emit_expr(where_expr, sb);
+        }
+        return sb.finish();
+    }
+
     // Build an INSERT statement string.
     sql_parser::StringRef build_insert(
             const TableInfo* table,

--- a/include/sql_engine/session.h
+++ b/include/sql_engine/session.h
@@ -126,15 +126,16 @@ public:
         std::string sql_key(sql, len);
         auto cache_it = plan_cache_.find(sql_key);
         if (cache_it != plan_cache_.end()) {
-            // Cache hit: move this entry to the front of the LRU list.
             plan_cache_order_.splice(plan_cache_order_.begin(),
                                      plan_cache_order_,
                                      cache_it->second);
             exec_arena_.reset();
             auto& entry = *cache_it->second;
+            PlanNode* plan = maybe_distribute(entry.plan, exec_arena_);
+            if (!plan) return {};
             PlanExecutor<D> executor(functions_, catalog_, exec_arena_);
             wire_executor(executor);
-            return executor.execute(entry.plan);
+            return executor.execute(plan);
         }
 
         // Cache miss: full parse -> plan -> optimize -> distribute pipeline
@@ -164,25 +165,21 @@ public:
 
         plan = optimizer_.optimize(plan, cached_parser->arena());
 
-        // Distribute across shards if shard map is configured
+        ResultSet rs;
         if (shard_map_ && remote_executor_) {
-            DistributedPlanner<D> dplanner(*shard_map_, catalog_, cached_parser->arena(), remote_executor_, &functions_);
-            plan = dplanner.distribute(plan);
+            exec_arena_.reset();
+            PlanNode* dist = maybe_distribute(plan, exec_arena_);
+            if (!dist) return {};
+            PlanExecutor<D> executor(functions_, catalog_, exec_arena_);
+            wire_executor(executor);
+            rs = executor.execute(dist);
+        } else {
+            PlanExecutor<D> executor(functions_, catalog_, cached_parser->arena());
+            wire_executor(executor);
+            rs = executor.execute(plan);
         }
 
-        // Execute first using the parser's arena. preprocess_aggregates (called
-        // inside execute()) may allocate into the arena to modify the plan in-place.
-        // Those allocations must persist in the parser arena (not exec_arena_) so
-        // the cached plan remains valid across calls.
-        PlanExecutor<D> executor(functions_, catalog_, cached_parser->arena());
-        wire_executor(executor);
-        ResultSet rs = executor.execute(plan);
-
-        // Cache the plan, enforcing the LRU bound. The parser arena is kept
-        // alive via unique_ptr stored in the CachedPlan so all plan/AST
-        // string pointers remain valid for subsequent cache hits.
         insert_into_plan_cache(std::move(sql_key), std::move(cached_parser), plan);
-
         return rs;
     }
 
@@ -377,6 +374,15 @@ private:
     CacheList plan_cache_order_;
     std::unordered_map<std::string, CacheIter> plan_cache_;
     size_t plan_cache_max_size_ = 1024;
+
+    PlanNode* maybe_distribute(PlanNode* plan, sql_parser::Arena& arena) {
+        if (!plan || !shard_map_ || !remote_executor_) return plan;
+        DistributedPlanner<D> dplanner(*shard_map_, catalog_, arena,
+                                       remote_executor_, &functions_);
+        PlanNode* dist = dplanner.distribute(plan);
+        if (dplanner.last_error()) return nullptr;
+        return dist;
+    }
 
     void insert_into_plan_cache(std::string key,
                                 std::unique_ptr<sql_parser::Parser<D>> parser,

--- a/include/sql_engine/session.h
+++ b/include/sql_engine/session.h
@@ -224,7 +224,10 @@ public:
                                       remote_executor_, &functions_);
             PlanNode* dist_plan = dp.distribute_dml(plan);
 
-            if (dist_plan && dist_plan->type == PlanNodeType::REMOTE_SCAN) {
+            if (dp.last_error()) {
+                result.success = false;
+                result.error_message = dp.last_error();
+            } else if (dist_plan && dist_plan->type == PlanNodeType::REMOTE_SCAN) {
                 // Single-shard DML
                 sql_parser::StringRef sql_ref{dist_plan->remote_scan.remote_sql,
                                               dist_plan->remote_scan.remote_sql_len};

--- a/include/sql_engine/session.h
+++ b/include/sql_engine/session.h
@@ -13,6 +13,7 @@
 #include "sql_engine/result_set.h"
 #include "sql_engine/dml_result.h"
 #include "sql_engine/mutable_data_source.h"
+#include "sql_engine/remote_executor.h"
 #include "sql_parser/parser.h"
 #include "sql_parser/common.h"
 
@@ -24,6 +25,44 @@
 #include <memory>
 
 namespace sql_engine {
+
+class TxnRoutingExecutor : public RemoteExecutor {
+public:
+    void bind(RemoteExecutor* inner, TransactionManager* txn) {
+        inner_ = inner;
+        txn_ = txn;
+    }
+
+    ResultSet execute(const char* backend_name, sql_parser::StringRef sql) override {
+        if (txn_ && txn_->in_transaction() && txn_->is_distributed() &&
+            txn_->route_query_supported()) {
+            return txn_->route_query(backend_name, sql);
+        }
+        return inner_ ? inner_->execute(backend_name, sql) : ResultSet{};
+    }
+
+    DmlResult execute_dml(const char* backend_name, sql_parser::StringRef sql) override {
+        if (txn_ && txn_->in_transaction() && txn_->is_distributed()) {
+            return txn_->route_dml(backend_name, sql);
+        }
+        if (inner_) return inner_->execute_dml(backend_name, sql);
+        DmlResult r;
+        r.error_message = "no remote executor";
+        return r;
+    }
+
+    bool allows_unpinned_distributed_2pc() const override {
+        return inner_ && inner_->allows_unpinned_distributed_2pc();
+    }
+
+    std::unique_ptr<RemoteSession> checkout_session(const char* backend_name) override {
+        return inner_ ? inner_->checkout_session(backend_name) : nullptr;
+    }
+
+private:
+    RemoteExecutor* inner_ = nullptr;
+    TransactionManager* txn_ = nullptr;
+};
 
 // Session<D> is the high-level API that ties together parsing, planning,
 // optimization, execution, and transaction management.
@@ -306,6 +345,7 @@ private:
     FunctionRegistry<D> functions_;
     Optimizer<D> optimizer_;
     RemoteExecutor* remote_executor_ = nullptr;
+    TxnRoutingExecutor routing_exec_;
     const ShardMap* shard_map_ = nullptr;
     bool parallel_open_enabled_ = false;
     std::unordered_map<std::string, DataSource*> sources_;
@@ -377,8 +417,10 @@ private:
             executor.add_data_source(kv.first.c_str(), kv.second);
         for (auto& kv : mutable_sources_)
             executor.add_mutable_data_source(kv.first.c_str(), kv.second);
-        if (remote_executor_)
-            executor.set_remote_executor(remote_executor_);
+        if (remote_executor_) {
+            routing_exec_.bind(remote_executor_, &txn_mgr_);
+            executor.set_remote_executor(&routing_exec_);
+        }
         if (parallel_open_enabled_) {
             executor.set_parallel_open(true);
             if (pool_)

--- a/include/sql_engine/shard_map.h
+++ b/include/sql_engine/shard_map.h
@@ -3,6 +3,7 @@
 
 #include "sql_parser/common.h"
 #include <cstdint>
+#include <climits>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -153,6 +154,32 @@ public:
                 return 0;
         }
         return 0;
+    }
+
+    RoutingStrategy routing_strategy(sql_parser::StringRef table_name) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        return cfg ? cfg->strategy : RoutingStrategy::HASH;
+    }
+
+    // RANGE only. Inclusive [lo, hi]. HASH/LIST yield no indices (caller scatters).
+    void collect_int_range_shards(sql_parser::StringRef table_name,
+                                  int64_t lo, int64_t hi,
+                                  std::vector<size_t>& out) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        if (!cfg || cfg->strategy != RoutingStrategy::RANGE || cfg->ranges.empty())
+            return;
+        if (lo > hi) return;
+        size_t n = cfg->shards.size();
+        const auto& ranges = cfg->ranges;
+        for (size_t i = 0; i < ranges.size(); ++i) {
+            int64_t seg_hi = (i + 1 == ranges.size())
+                ? INT64_MAX : ranges[i].upper_inclusive;
+            int64_t seg_lo = (i == 0) ? INT64_MIN
+                : (cfg->ranges[i - 1].upper_inclusive == INT64_MAX
+                   ? INT64_MAX : cfg->ranges[i - 1].upper_inclusive + 1);
+            if (seg_lo <= hi && seg_hi >= lo)
+                out.push_back(clamp_index(ranges[i].shard_index, n));
+        }
     }
 
     bool same_routing(sql_parser::StringRef a, sql_parser::StringRef b) const {

--- a/include/sql_engine/shard_map.h
+++ b/include/sql_engine/shard_map.h
@@ -155,6 +155,34 @@ public:
         return 0;
     }
 
+    bool same_routing(sql_parser::StringRef a, sql_parser::StringRef b) const {
+        const TableShardConfig* ca = lookup(a);
+        const TableShardConfig* cb = lookup(b);
+        if (!ca || !cb) return false;
+        if (ca->strategy != cb->strategy) return false;
+        if (ca->shards.size() != cb->shards.size() || ca->shards.empty()) return false;
+        for (size_t i = 0; i < ca->shards.size(); ++i) {
+            if (ca->shards[i].backend_name != cb->shards[i].backend_name) return false;
+        }
+        if (ca->strategy == RoutingStrategy::RANGE) {
+            if (ca->ranges.size() != cb->ranges.size()) return false;
+            for (size_t i = 0; i < ca->ranges.size(); ++i) {
+                if (ca->ranges[i].upper_inclusive != cb->ranges[i].upper_inclusive ||
+                    ca->ranges[i].shard_index != cb->ranges[i].shard_index) return false;
+            }
+        }
+        if (ca->strategy == RoutingStrategy::LIST) {
+            if (ca->list.size() != cb->list.size()) return false;
+            for (size_t i = 0; i < ca->list.size(); ++i) {
+                if (ca->list[i].is_int != cb->list[i].is_int ||
+                    ca->list[i].int_val != cb->list[i].int_val ||
+                    ca->list[i].str_val != cb->list[i].str_val ||
+                    ca->list[i].shard_index != cb->list[i].shard_index) return false;
+            }
+        }
+        return true;
+    }
+
     // Get the single backend for an unsharded table.
     const char* get_backend(sql_parser::StringRef table_name) const {
         const TableShardConfig* cfg = lookup(table_name);

--- a/include/sql_engine/shard_map.h
+++ b/include/sql_engine/shard_map.h
@@ -51,19 +51,34 @@ struct ShardListEntry {
     size_t shard_index = 0;
 };
 
+// One component of a (possibly composite) shard key. n==1 reuses the
+// single-column HASH/RANGE/LIST path so existing routes stay identical.
+struct ShardKeyPart {
+    bool is_int = true;
+    int64_t int_val = 0;
+    const char* str = nullptr;
+    uint32_t str_len = 0;
+};
+
 struct TableShardConfig {
     std::string table_name;
-    std::string shard_key;          // empty if unsharded
+    std::string shard_key;          // empty if unsharded; "a+b" for composite
     std::vector<ShardInfo> shards;  // 1 if unsharded, N if sharded
     RoutingStrategy strategy = RoutingStrategy::HASH;
     std::vector<ShardRange> ranges;       // used iff strategy == RANGE
     std::vector<ShardListEntry> list;     // used iff strategy == LIST
+    std::vector<std::string> shard_keys;  // filled by ShardMap::add_table
 };
 
 class ShardMap {
 public:
     void add_table(const TableShardConfig& config) {
         TableShardConfig copy = config;
+        if (copy.shard_keys.empty() && !copy.shard_key.empty()) {
+            split_keys(copy.shard_key, copy.shard_keys);
+        } else if (copy.shard_key.empty() && !copy.shard_keys.empty()) {
+            copy.shard_key = join_keys(copy.shard_keys);
+        }
         if (copy.strategy == RoutingStrategy::RANGE) {
             std::sort(copy.ranges.begin(), copy.ranges.end(),
                       [](const ShardRange& a, const ShardRange& b) {
@@ -77,7 +92,7 @@ public:
     bool is_sharded(sql_parser::StringRef table_name) const {
         const TableShardConfig* cfg = lookup(table_name);
         if (!cfg) return false;
-        return !cfg->shard_key.empty() && cfg->shards.size() > 1;
+        return !cfg->shard_keys.empty() && cfg->shards.size() > 1;
     }
 
     const std::vector<ShardInfo>& get_shards(sql_parser::StringRef table_name) const {
@@ -89,20 +104,109 @@ public:
 
     sql_parser::StringRef get_shard_key(sql_parser::StringRef table_name) const {
         const TableShardConfig* cfg = lookup(table_name);
-        if (cfg && !cfg->shard_key.empty()) {
-            const std::string& sk = cfg->shard_key;
+        if (cfg && !cfg->shard_keys.empty()) {
+            const std::string& sk = cfg->shard_keys[0];
             return sql_parser::StringRef{sk.c_str(), static_cast<uint32_t>(sk.size())};
         }
         return sql_parser::StringRef{nullptr, 0};
+    }
+
+    const std::vector<std::string>& get_shard_keys(sql_parser::StringRef table_name) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        if (cfg) return cfg->shard_keys;
+        static const std::vector<std::string> empty;
+        return empty;
     }
 
     bool has_table(sql_parser::StringRef table_name) const {
         return lookup(table_name) != nullptr;
     }
 
+    // False if the table is unknown, has no shards, or a LIST value is unmapped.
+    bool try_shard_index_for_int(sql_parser::StringRef table_name, int64_t value,
+                                 size_t& out) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        if (!cfg || cfg->shards.empty()) return false;
+        size_t n = cfg->shards.size();
+        switch (cfg->strategy) {
+            case RoutingStrategy::HASH:
+                out = fnv1a_int64(value) % n;
+                return true;
+            case RoutingStrategy::RANGE:
+                out = shard_index_for_int(table_name, value);
+                return true;
+            case RoutingStrategy::LIST:
+                for (const auto& e : cfg->list) {
+                    if (e.is_int && e.int_val == value) {
+                        out = clamp_index(e.shard_index, n);
+                        return true;
+                    }
+                }
+                return false;
+        }
+        return false;
+    }
+
+    bool try_shard_index_for_string(sql_parser::StringRef table_name,
+                                    const char* val, uint32_t val_len,
+                                    size_t& out) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        if (!cfg || cfg->shards.empty()) return false;
+        size_t n = cfg->shards.size();
+        switch (cfg->strategy) {
+            case RoutingStrategy::HASH:
+                out = fnv1a_bytes(reinterpret_cast<const uint8_t*>(val), val_len) % n;
+                return true;
+            case RoutingStrategy::RANGE:
+                return false;
+            case RoutingStrategy::LIST:
+                for (const auto& e : cfg->list) {
+                    if (!e.is_int && e.str_val.size() == val_len &&
+                        std::memcmp(e.str_val.data(), val, val_len) == 0) {
+                        out = clamp_index(e.shard_index, n);
+                        return true;
+                    }
+                }
+                return false;
+        }
+        return false;
+    }
+
+    bool try_shard_index_for_parts(sql_parser::StringRef table_name,
+                                   const ShardKeyPart* parts, size_t n,
+                                   size_t& out) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        if (!cfg || cfg->shards.empty() || !parts || n == 0) return false;
+        if (n == 1) {
+            return parts[0].is_int
+                ? try_shard_index_for_int(table_name, parts[0].int_val, out)
+                : try_shard_index_for_string(table_name, parts[0].str,
+                                             parts[0].str_len, out);
+        }
+        if (cfg->strategy != RoutingStrategy::HASH) return false;
+        uint64_t h = 0xcbf29ce484222325ULL;
+        for (size_t i = 0; i < n; ++i) {
+            if (parts[i].is_int) {
+                uint64_t u = static_cast<uint64_t>(parts[i].int_val);
+                uint8_t bytes[8];
+                for (int b = 0; b < 8; ++b)
+                    bytes[b] = static_cast<uint8_t>((u >> (b * 8)) & 0xff);
+                h = fnv1a_mix(h, bytes, 8);
+            } else {
+                h = fnv1a_mix(h,
+                              reinterpret_cast<const uint8_t*>(parts[i].str),
+                              parts[i].str_len);
+            }
+            uint8_t sep = 0xff;
+            h = fnv1a_mix(h, &sep, 1);
+        }
+        out = static_cast<size_t>(h % cfg->shards.size());
+        return true;
+    }
+
     // Determine which shard index a value maps to. Dispatches on the
     // configured RoutingStrategy. Returns 0 if the table is unknown or
-    // has no shards.
+    // has no shards — prefer try_shard_index_for_* which fails closed.
     size_t shard_index_for_int(sql_parser::StringRef table_name, int64_t value) const {
         const TableShardConfig* cfg = lookup(table_name);
         if (!cfg || cfg->shards.empty()) return 0;
@@ -159,6 +263,21 @@ public:
     RoutingStrategy routing_strategy(sql_parser::StringRef table_name) const {
         const TableShardConfig* cfg = lookup(table_name);
         return cfg ? cfg->strategy : RoutingStrategy::HASH;
+    }
+
+    // LIST only. Inclusive [lo, hi]. Pushes every mapped int in the window.
+    void collect_int_list_shards(sql_parser::StringRef table_name,
+                                 int64_t lo, int64_t hi,
+                                 std::vector<size_t>& out) const {
+        const TableShardConfig* cfg = lookup(table_name);
+        if (!cfg || cfg->strategy != RoutingStrategy::LIST || cfg->list.empty())
+            return;
+        if (lo > hi) return;
+        size_t n = cfg->shards.size();
+        for (const auto& e : cfg->list) {
+            if (e.is_int && e.int_val >= lo && e.int_val <= hi)
+                out.push_back(clamp_index(e.shard_index, n));
+        }
     }
 
     // RANGE only. Inclusive [lo, hi]. HASH/LIST yield no indices (caller scatters).
@@ -238,15 +357,43 @@ private:
         return idx < n ? idx : (n == 0 ? 0 : n - 1);
     }
 
+    static void split_keys(const std::string& spec, std::vector<std::string>& out) {
+        size_t start = 0;
+        while (start <= spec.size()) {
+            size_t plus = spec.find('+', start);
+            if (plus == std::string::npos) {
+                out.push_back(spec.substr(start));
+                break;
+            }
+            out.push_back(spec.substr(start, plus - start));
+            start = plus + 1;
+        }
+        out.erase(std::remove_if(out.begin(), out.end(),
+                                 [](const std::string& s) { return s.empty(); }),
+                  out.end());
+    }
+
+    static std::string join_keys(const std::vector<std::string>& keys) {
+        std::string out;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (i) out += '+';
+            out += keys[i];
+        }
+        return out;
+    }
+
     // FNV-1a 64-bit. Deterministic across compilers, fast, good enough for
     // shard-key routing where adversarial inputs are not a concern.
-    static uint64_t fnv1a_bytes(const uint8_t* data, size_t len) {
-        uint64_t h = 0xcbf29ce484222325ULL;
+    static uint64_t fnv1a_mix(uint64_t h, const uint8_t* data, size_t len) {
         for (size_t i = 0; i < len; ++i) {
             h ^= static_cast<uint64_t>(data[i]);
             h *= 0x100000001b3ULL;
         }
         return h;
+    }
+
+    static uint64_t fnv1a_bytes(const uint8_t* data, size_t len) {
+        return fnv1a_mix(0xcbf29ce484222325ULL, data, len);
     }
 
     static uint64_t fnv1a_int64(int64_t v) {

--- a/include/sql_engine/shard_map.h
+++ b/include/sql_engine/shard_map.h
@@ -177,7 +177,7 @@ public:
                                    size_t& out) const {
         const TableShardConfig* cfg = lookup(table_name);
         if (!cfg || cfg->shards.empty() || !parts || n == 0) return false;
-        if (n == 1) {
+        if (n == 1 || cfg->strategy == RoutingStrategy::RANGE) {
             return parts[0].is_int
                 ? try_shard_index_for_int(table_name, parts[0].int_val, out)
                 : try_shard_index_for_string(table_name, parts[0].str,

--- a/include/sql_engine/thread_safe_executor.h
+++ b/include/sql_engine/thread_safe_executor.h
@@ -14,6 +14,7 @@
 #include "sql_engine/remote_executor.h"
 #include "sql_engine/remote_session.h"
 #include "sql_engine/connection_pool.h"
+#include "sql_engine/pg_connection_pool.h"
 #include "sql_engine/backend_config.h"
 #include "sql_engine/result_set.h"
 #include "sql_engine/dml_result.h"
@@ -23,6 +24,7 @@
 #include "sql_parser/common.h"
 
 #include <mysql/mysql.h>
+#include <libpq-fe.h>
 #include <memory>
 #include <string>
 #include <cstdlib>
@@ -127,6 +129,89 @@ inline ResultSet mysql_result_to_resultset_impl(MYSQL_RES* res) {
                 rs, mysql_row[i], is_null ? 0 : lengths[i],
                 fields[i].type, is_null);
             row.set(static_cast<uint16_t>(i), v);
+        }
+    }
+    return rs;
+}
+
+#ifndef BOOLOID
+#define BOOLOID         16
+#define INT2OID         21
+#define INT4OID         23
+#define INT8OID         20
+#define FLOAT4OID       700
+#define FLOAT8OID       701
+#define NUMERICOID      1700
+#define DATEOID         1082
+#define TIMEOID         1083
+#define TIMESTAMPOID    1114
+#define TIMESTAMPTZOID  1184
+#define BYTEAOID        17
+#define JSONOID         114
+#define JSONBOID        3802
+#define OIDOID          26
+#endif
+
+inline Value pg_field_to_value_impl(
+    ResultSet& rs, const char* data, int length, Oid type, bool is_null)
+{
+    if (is_null) return value_null();
+    switch (type) {
+        case BOOLOID:
+            return value_bool(data[0] == 't' || data[0] == 'T');
+        case INT2OID:
+        case INT4OID:
+        case INT8OID:
+        case OIDOID:
+            return value_int(std::strtoll(data, nullptr, 10));
+        case FLOAT4OID:
+        case FLOAT8OID:
+            return value_double(std::strtod(data, nullptr));
+        case NUMERICOID: {
+            sql_parser::StringRef s = rs.own_string(data, static_cast<uint32_t>(length));
+            return value_string(s);
+        }
+        case DATEOID:
+            return value_date(datetime_parse::parse_date(data));
+        case TIMESTAMPOID:
+            return value_datetime(datetime_parse::parse_datetime(data));
+        case TIMESTAMPTZOID:
+            return value_timestamp(datetime_parse::parse_datetime_tz(data));
+        case TIMEOID:
+            return value_time(datetime_parse::parse_time(data));
+        case BYTEAOID: {
+            sql_parser::StringRef s = rs.own_string(data, static_cast<uint32_t>(length));
+            return value_bytes(s);
+        }
+        case JSONOID:
+        case JSONBOID: {
+            sql_parser::StringRef s = rs.own_string(data, static_cast<uint32_t>(length));
+            return value_json(s);
+        }
+        default: {
+            sql_parser::StringRef s = rs.own_string(data, static_cast<uint32_t>(length));
+            return value_string(s);
+        }
+    }
+}
+
+inline ResultSet pg_result_to_resultset_impl(PGresult* res) {
+    ResultSet rs;
+    int num_fields = PQnfields(res);
+    int num_rows = PQntuples(res);
+    rs.column_count = static_cast<uint16_t>(num_fields);
+    for (int i = 0; i < num_fields; ++i) {
+        rs.column_names.emplace_back(PQfname(res, i));
+    }
+    for (int r = 0; r < num_rows; ++r) {
+        Row& row = rs.add_heap_row(rs.column_count);
+        for (int c = 0; c < num_fields; ++c) {
+            bool is_null = PQgetisnull(res, r, c) != 0;
+            Oid oid = PQftype(res, c);
+            const char* data = PQgetvalue(res, r, c);
+            int length = PQgetlength(res, r, c);
+            row.set(static_cast<uint16_t>(c),
+                    pg_field_to_value_impl(rs, data, length, oid, is_null));
         }
     }
     return rs;
@@ -280,19 +365,122 @@ private:
     bool poisoned_ = false;
 };
 
+class PgConnectionGuard {
+public:
+    PgConnectionGuard(PgConnectionPool& pool, std::string name)
+        : pool_(pool), name_(std::move(name)), conn_(pool_.checkout(name_)) {}
+    ~PgConnectionGuard() {
+        if (!conn_) return;
+        if (poisoned_) PQfinish(conn_);
+        else pool_.checkin(name_, conn_);
+    }
+    PgConnectionGuard(const PgConnectionGuard&) = delete;
+    PgConnectionGuard& operator=(const PgConnectionGuard&) = delete;
+    PGconn* get() const { return conn_; }
+    void poison() { poisoned_ = true; }
+private:
+    PgConnectionPool& pool_;
+    std::string name_;
+    PGconn* conn_;
+    bool poisoned_ = false;
+};
+
+class PooledPgSession : public RemoteSession {
+public:
+    PooledPgSession(PgConnectionPool& pool, std::string name)
+        : pool_(pool), name_(std::move(name)), conn_(pool_.checkout(name_)) {}
+    ~PooledPgSession() override {
+        if (!conn_) return;
+        if (poisoned_) PQfinish(conn_);
+        else pool_.checkin(name_, conn_);
+    }
+    PooledPgSession(const PooledPgSession&) = delete;
+    PooledPgSession& operator=(const PooledPgSession&) = delete;
+
+    ResultSet execute(sql_parser::StringRef sql) override {
+        ResultSet rs;
+        if (!conn_) { poisoned_ = true; return rs; }
+        std::string q(sql.ptr, sql.len);
+        PGresult* res = PQexec(conn_, q.c_str());
+        if (!res) { poisoned_ = true; return rs; }
+        ExecStatusType st = PQresultStatus(res);
+        if (st != PGRES_TUPLES_OK) {
+            PQclear(res);
+            return rs;
+        }
+        rs = detail::pg_result_to_resultset_impl(res);
+        PQclear(res);
+        return rs;
+    }
+
+    DmlResult execute_dml(sql_parser::StringRef sql) override {
+        DmlResult result;
+        if (!conn_) {
+            poisoned_ = true;
+            result.error_message = "no connection";
+            return result;
+        }
+        std::string q(sql.ptr, sql.len);
+        PGresult* res = PQexec(conn_, q.c_str());
+        if (!res) {
+            poisoned_ = true;
+            result.error_message = "PQexec returned null";
+            return result;
+        }
+        ExecStatusType st = PQresultStatus(res);
+        if (st != PGRES_COMMAND_OK && st != PGRES_TUPLES_OK) {
+            result.error_message = PQresultErrorMessage(res);
+            PQclear(res);
+            return result;
+        }
+        const char* tuples = PQcmdTuples(res);
+        if (tuples && tuples[0])
+            result.affected_rows = static_cast<uint64_t>(std::strtoull(tuples, nullptr, 10));
+        result.success = true;
+        PQclear(res);
+        return result;
+    }
+
+    void poison() override { poisoned_ = true; }
+
+private:
+    PgConnectionPool& pool_;
+    std::string name_;
+    PGconn* conn_;
+    bool poisoned_ = false;
+};
+
 class ThreadSafeMultiRemoteExecutor : public RemoteExecutor {
 public:
     ThreadSafeMultiRemoteExecutor() = default;
     ~ThreadSafeMultiRemoteExecutor() override = default;
 
     void add_backend(const BackendConfig& config) {
-        pool_.add_backend(config);
-        // Track dialect per backend (currently only MySQL is pooled)
         std::lock_guard<std::mutex> lk(mu_);
         backend_dialects_[config.name] = config.dialect;
+        if (config.dialect == sql_parser::Dialect::PostgreSQL)
+            pg_pool_.add_backend(config);
+        else
+            pool_.add_backend(config);
     }
 
     ResultSet execute(const char* backend_name, sql_parser::StringRef sql) override {
+        if (is_pg(backend_name)) {
+            PgConnectionGuard guard(pg_pool_, std::string(backend_name));
+            ResultSet rs;
+            PGconn* conn = guard.get();
+            if (!conn) { guard.poison(); return rs; }
+            std::string q(sql.ptr, sql.len);
+            PGresult* res = PQexec(conn, q.c_str());
+            if (!res) { guard.poison(); return rs; }
+            if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+                PQclear(res);
+                return rs;
+            }
+            rs = detail::pg_result_to_resultset_impl(res);
+            PQclear(res);
+            return rs;
+        }
         ConnectionGuard guard(pool_, std::string(backend_name));
         ResultSet rs;
         MYSQL* conn = guard.get();
@@ -326,6 +514,35 @@ public:
     }
 
     DmlResult execute_dml(const char* backend_name, sql_parser::StringRef sql) override {
+        if (is_pg(backend_name)) {
+            PgConnectionGuard guard(pg_pool_, std::string(backend_name));
+            DmlResult result;
+            PGconn* conn = guard.get();
+            if (!conn) {
+                guard.poison();
+                result.error_message = "failed to acquire connection";
+                return result;
+            }
+            std::string q(sql.ptr, sql.len);
+            PGresult* res = PQexec(conn, q.c_str());
+            if (!res) {
+                guard.poison();
+                result.error_message = "PQexec returned null";
+                return result;
+            }
+            ExecStatusType st = PQresultStatus(res);
+            if (st != PGRES_COMMAND_OK && st != PGRES_TUPLES_OK) {
+                result.error_message = PQresultErrorMessage(res);
+                PQclear(res);
+                return result;
+            }
+            const char* tuples = PQcmdTuples(res);
+            if (tuples && tuples[0])
+                result.affected_rows = static_cast<uint64_t>(std::strtoull(tuples, nullptr, 10));
+            result.success = true;
+            PQclear(res);
+            return result;
+        }
         ConnectionGuard guard(pool_, std::string(backend_name));
         DmlResult result;
         MYSQL* conn = guard.get();
@@ -363,6 +580,8 @@ public:
     // the connection is returned to the pool on destruction (or closed
     // if the session was poisoned).
     std::unique_ptr<RemoteSession> checkout_session(const char* backend_name) override {
+        if (is_pg(backend_name))
+            return std::make_unique<PooledPgSession>(pg_pool_, std::string(backend_name));
         return std::make_unique<PooledMySQLSession>(pool_, std::string(backend_name));
     }
 
@@ -372,8 +591,16 @@ public:
 
 private:
     ConnectionPool pool_;
-    std::mutex mu_;
+    PgConnectionPool pg_pool_;
+    mutable std::mutex mu_;
     std::unordered_map<std::string, sql_parser::Dialect> backend_dialects_;
+
+    bool is_pg(const char* backend_name) const {
+        std::lock_guard<std::mutex> lk(mu_);
+        auto it = backend_dialects_.find(backend_name ? backend_name : "");
+        return it != backend_dialects_.end() &&
+               it->second == sql_parser::Dialect::PostgreSQL;
+    }
 
     // Wrap the free function for the legacy (unpinned) pooled execute path.
     static ResultSet mysql_result_to_resultset(MYSQL_RES* res) {

--- a/include/sql_engine/transaction_manager.h
+++ b/include/sql_engine/transaction_manager.h
@@ -2,6 +2,7 @@
 #define SQL_ENGINE_TRANSACTION_MANAGER_H
 
 #include "sql_engine/dml_result.h"
+#include "sql_engine/result_set.h"
 #include "sql_parser/common.h"
 
 namespace sql_engine {
@@ -40,6 +41,13 @@ public:
         r.error_message = "route_dml not supported by this transaction manager";
         return r;
     }
+
+    virtual ResultSet route_query(const char* /*backend_name*/,
+                                  sql_parser::StringRef /*sql*/) {
+        return {};
+    }
+
+    virtual bool route_query_supported() const { return false; }
 };
 
 } // namespace sql_engine

--- a/include/sql_parser/common.h
+++ b/include/sql_parser/common.h
@@ -66,6 +66,10 @@ static constexpr uint16_t FLAG_SET_OP_ALL = 0x01;
 // which matters for SHOW search_path / SHOW <var> canonical re-emission.
 static constexpr uint16_t FLAG_IDENT_DELIMITED = 0x01;
 
+// -- Flags for NODE_FUNCTION_CALL --
+// Set when the call was written as FN(DISTINCT ...).
+static constexpr uint16_t FLAG_FUNC_DISTINCT = 0x01;
+
 // -- Statement type (always set, even for PARTIAL/ERROR) --
 
 enum class StmtType : uint8_t {

--- a/include/sql_parser/emitter.h
+++ b/include/sql_parser/emitter.h
@@ -1116,6 +1116,7 @@ private:
     void emit_function_call(const AstNode* node) {
         emit_value(node);
         sb_.append_char('(');
+        if (node->flags & FLAG_FUNC_DISTINCT) sb_.append("DISTINCT ");
         bool first = true;
         for (const AstNode* arg = node->first_child; arg; arg = arg->next_sibling) {
             if (!first) sb_.append(", ");

--- a/include/sql_parser/expression_parser.h
+++ b/include/sql_parser/expression_parser.h
@@ -331,6 +331,10 @@ private:
             // argument list. Model it as a function call so consumers can
             // reject or handle the expression without leaving valid input
             // unconsumed.
+            if (tok_.peek().type == TokenType::TK_DISTINCT) {
+                func->flags |= FLAG_FUNC_DISTINCT;
+                tok_.skip();
+            }
             if (name_token.text.equals_ci("CAST", 4)) {
                 AstNode* arg = parse();
                 if (!arg || tok_.peek().type != TokenType::TK_AS) return func;

--- a/scripts/run_pg_sharding_demo.sh
+++ b/scripts/run_pg_sharding_demo.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# RANGE + LIST + 2PC against the two PostgreSQL shards.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+if ! docker exec parsersql-pg-shard1 pg_isready -Upostgres &>/dev/null 2>&1; then
+    echo "ERROR: PG shards not running. Start them with: ./scripts/start_pg_sharding_demo.sh"
+    exit 1
+fi
+
+if [ ! -f ./sqlengine ]; then
+    echo "Building sqlengine..."
+    make build-sqlengine
+fi
+
+PG1='pgsql://postgres:test@127.0.0.1:16432/testdb?name=pg1'
+PG2='pgsql://postgres:test@127.0.0.1:16433/testdb?name=pg2'
+TXN_LOG="${TMPDIR:-/tmp}/parsersql-pg-demo.txn"
+
+run_sql() {
+    local desc="$1"
+    local sql="$2"
+    echo "----------------------------------------------"
+    echo "QUERY: $desc"
+    echo "SQL:   $sql"
+    echo ""
+    echo "$sql" | ./sqlengine \
+        --backend "$PG1" \
+        --backend "$PG2" \
+        --shard "users:id:range:5=pg1,10=pg2" \
+        --shard "regions:name:list:us-east=pg1,us-west=pg2" \
+        --shard "orders:id:range:105=pg1,110=pg2" \
+        --txn-log "$TXN_LOG" \
+        2>&1
+    echo ""
+}
+
+echo "=============================================="
+echo "  PostgreSQL LIST + RANGE + 2PC demo"
+echo "=============================================="
+echo "  pg1 :16432  users 1-5 / us-east"
+echo "  pg2 :16433  users 6-10 / us-west"
+echo ""
+
+run_sql "RANGE point lookup" \
+    "SELECT name FROM users WHERE id = 3"
+
+run_sql "RANGE BETWEEN prune" \
+    "SELECT name FROM users WHERE id BETWEEN 6 AND 10"
+
+run_sql "LIST point lookup" \
+    "SELECT tz FROM regions WHERE name = 'us-west'"
+
+run_sql "Scatter scan" \
+    "SELECT COUNT(*) FROM users"
+
+echo "=============================================="
+echo "  2PC write across both shards (one engine)"
+echo "=============================================="
+{
+    echo "BEGIN"
+    echo "INSERT INTO users (id, name, age) VALUES (0, 'Zero', 1)"
+    echo "INSERT INTO users (id, name, age) VALUES (11, 'Eleven', 2)"
+    echo "COMMIT"
+} | ./sqlengine \
+    --backend "$PG1" \
+    --backend "$PG2" \
+    --shard "users:id:range:5=pg1,10=pg2" \
+    --shard "regions:name:list:us-east=pg1,us-west=pg2" \
+    --shard "orders:id:range:105=pg1,110=pg2" \
+    --txn-log "$TXN_LOG" \
+    2>&1
+echo ""
+
+run_sql "Read back 2PC inserts" \
+    "SELECT id, name FROM users WHERE id IN (0, 11)"
+
+echo "Demo complete. Stop: docker rm -f parsersql-pg-shard1 parsersql-pg-shard2"

--- a/scripts/start_pg_sharding_demo.sh
+++ b/scripts/start_pg_sharding_demo.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Two PostgreSQL shards for LIST + RANGE + 2PC. Ports 16432/16433
+# (15432 is the unit-test backend; 13306 is the MySQL sharding demo).
+set -e
+
+echo "=== Starting 2-shard PostgreSQL demo ==="
+
+docker rm -f parsersql-pg-shard1 parsersql-pg-shard2 2>/dev/null || true
+
+docker run -d --name parsersql-pg-shard1 \
+    -p 16432:5432 \
+    -e POSTGRES_PASSWORD=test \
+    -e POSTGRES_DB=testdb \
+    postgres:16 \
+    -c max_prepared_transactions=16
+
+docker run -d --name parsersql-pg-shard2 \
+    -p 16433:5432 \
+    -e POSTGRES_PASSWORD=test \
+    -e POSTGRES_DB=testdb \
+    postgres:16 \
+    -c max_prepared_transactions=16
+
+echo "Waiting for PG shard 1..."
+until docker exec parsersql-pg-shard1 pg_isready -Upostgres &>/dev/null 2>&1; do sleep 1; done
+echo "PG shard 1 ready"
+
+echo "Waiting for PG shard 2..."
+until docker exec parsersql-pg-shard2 pg_isready -Upostgres &>/dev/null 2>&1; do sleep 1; done
+echo "PG shard 2 ready"
+
+echo "Loading RANGE users 1-5 + LIST region us-east on shard 1..."
+docker exec -i parsersql-pg-shard1 psql -Upostgres testdb <<'SQL'
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS regions;
+
+CREATE TABLE users (
+    id INT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    age INT
+);
+CREATE TABLE regions (
+    name VARCHAR(64) PRIMARY KEY,
+    tz VARCHAR(32)
+);
+CREATE TABLE orders (
+    id INT PRIMARY KEY,
+    user_id INT,
+    total NUMERIC(10,2)
+);
+
+INSERT INTO users VALUES
+    (1, 'Alice', 30),
+    (2, 'Bob', 25),
+    (3, 'Carol', 35),
+    (4, 'Dave', 28),
+    (5, 'Eve', 32);
+INSERT INTO regions VALUES ('us-east', 'EST');
+INSERT INTO orders VALUES (101, 1, 150.00), (102, 3, 50.00);
+SQL
+
+echo "Loading RANGE users 6-10 + LIST region us-west on shard 2..."
+docker exec -i parsersql-pg-shard2 psql -Upostgres testdb <<'SQL'
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS regions;
+
+CREATE TABLE users (
+    id INT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    age INT
+);
+CREATE TABLE regions (
+    name VARCHAR(64) PRIMARY KEY,
+    tz VARCHAR(32)
+);
+CREATE TABLE orders (
+    id INT PRIMARY KEY,
+    user_id INT,
+    total NUMERIC(10,2)
+);
+
+INSERT INTO users VALUES
+    (6, 'Frank', 40),
+    (7, 'Grace', 22),
+    (8, 'Hank', 31),
+    (9, 'Ivy', 27),
+    (10, 'Jack', 36);
+INSERT INTO regions VALUES ('us-west', 'PST');
+INSERT INTO orders VALUES (106, 6, 80.00), (107, 8, 120.00);
+SQL
+
+echo "PostgreSQL shards ready:"
+echo "  pg1 127.0.0.1:16432  users 1-5, region us-east"
+echo "  pg2 127.0.0.1:16433  users 6-10, region us-west"
+echo "Run: ./scripts/run_pg_sharding_demo.sh"
+echo "Stop: docker rm -f parsersql-pg-shard1 parsersql-pg-shard2"

--- a/scripts/test_sqlengine.sh
+++ b/scripts/test_sqlengine.sh
@@ -290,6 +290,13 @@ test_sharded() {
     # Total = 890000.
     out=$(run_sharded "SELECT SUM(salary) FROM users")
     assert_contains "sharded: SUM(salary) all users = 890000" "${out}" "890000"
+
+    # Engine INSERT then point-SELECT must agree (RANGE routing).
+    out=$(run_sharded "INSERT INTO users (id, name, age, dept, salary) VALUES (11, 'Zed', 40, 'Test', 1)")
+    assert_contains "sharded: INSERT id=11" "${out}" "Query OK, 1 row"
+    out=$(run_sharded "SELECT name FROM users WHERE id = 11")
+    assert_contains "sharded: point SELECT after INSERT (Zed)" "${out}" "Zed"
+    run_sharded "DELETE FROM users WHERE id = 11" >/dev/null
 }
 
 # ----------------------------------------------------------------------

--- a/src/sql_engine/tool_config_parser.cpp
+++ b/src/sql_engine/tool_config_parser.cpp
@@ -208,10 +208,6 @@ ParsedShard parse_shard_spec(const std::string& spec) {
             return ps;
         }
     } else if (strategy_token == "range") {
-        if (ps.config.shard_key.find('+') != std::string::npos) {
-            ps.error = "composite shard keys require HASH strategy: " + spec;
-            return ps;
-        }
         ps.config.strategy = RoutingStrategy::RANGE;
         for (auto& entry : split_csv(body)) {
             std::string upper_str, backend;

--- a/src/sql_engine/tool_config_parser.cpp
+++ b/src/sql_engine/tool_config_parser.cpp
@@ -172,6 +172,10 @@ ParsedShard parse_shard_spec(const std::string& spec) {
 
     ps.config.table_name = spec.substr(0, c1);
     ps.config.shard_key = spec.substr(c1 + 1, c2 - c1 - 1);
+    if (ps.config.shard_key.empty()) {
+        ps.error = "Empty shard key in: " + spec;
+        return ps;
+    }
 
     // Look for an optional strategy qualifier in the next colon-separated
     // token: hash | range | list. If absent, default to HASH.
@@ -204,6 +208,10 @@ ParsedShard parse_shard_spec(const std::string& spec) {
             return ps;
         }
     } else if (strategy_token == "range") {
+        if (ps.config.shard_key.find('+') != std::string::npos) {
+            ps.error = "composite shard keys require HASH strategy: " + spec;
+            return ps;
+        }
         ps.config.strategy = RoutingStrategy::RANGE;
         for (auto& entry : split_csv(body)) {
             std::string upper_str, backend;
@@ -226,6 +234,10 @@ ParsedShard parse_shard_spec(const std::string& spec) {
             return ps;
         }
     } else if (strategy_token == "list") {
+        if (ps.config.shard_key.find('+') != std::string::npos) {
+            ps.error = "composite shard keys require HASH strategy: " + spec;
+            return ps;
+        }
         ps.config.strategy = RoutingStrategy::LIST;
         for (auto& entry : split_csv(body)) {
             std::string val_str, backend;

--- a/tests/test_distributed_dml.cpp
+++ b/tests/test_distributed_dml.cpp
@@ -307,9 +307,27 @@ protected:
 
         DistributedPlanner<Dialect::MySQL> dist(shard_map, catalog, parser.arena());
         PlanNode* dist_plan = dist.distribute_dml(plan);
+        if (dist.last_error()) {
+            DmlResult r;
+            r.error_message = dist.last_error();
+            return r;
+        }
 
-        // Execute all REMOTE_SCAN nodes in the distributed plan
         return execute_remote_dml_plan(dist_plan);
+    }
+
+    size_t shard_for_id(int64_t id) {
+        return shard_map.shard_index_for_int(StringRef{"users", 5}, id);
+    }
+
+    const char* backend_for_id(int64_t id) {
+        return shard_map.get_shards(StringRef{"users", 5})[shard_for_id(id)].backend_name.c_str();
+    }
+
+    size_t row_count_on(const char* backend, const char* table) {
+        auto* b = mock_executor.get_backend(backend);
+        auto it = b->mutable_sources.find(table);
+        return it == b->mutable_sources.end() ? 0u : it->second->row_count();
     }
 
     DmlResult execute_remote_dml_plan(PlanNode* plan) {
@@ -380,42 +398,34 @@ TEST_F(DistributedDmlTest, InsertUnsharded) {
     EXPECT_EQ(mock_executor.total_row_count("orders"), 1u);
 }
 
-// INSERT to sharded table -> route by shard key value
+// INSERT to sharded table -> route by ShardMap
 TEST_F(DistributedDmlTest, InsertShardedSingleRow) {
     mock_executor.clear_sql_logs();
 
-    // id=3 should route to shard 3%3=0
     auto result = execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
     EXPECT_TRUE(result.success);
     EXPECT_EQ(result.affected_rows, 1u);
 
-    // Only one shard should have the row
     EXPECT_EQ(mock_executor.total_row_count("users"), 1u);
-
-    // Specifically shard0 (3 % 3 == 0)
-    auto* s0 = mock_executor.get_backend("shard0");
-    auto it0 = s0->mutable_sources.find("users");
-    EXPECT_EQ(it0->second->row_count(), 1u);
+    EXPECT_EQ(row_count_on(backend_for_id(3), "users"), 1u);
 }
 
-// Multi-row INSERT to sharded -> rows grouped by shard
+// Multi-row INSERT to sharded -> rows grouped by ShardMap
 TEST_F(DistributedDmlTest, InsertShardedMultiRow) {
     mock_executor.clear_sql_logs();
 
-    // id=0 -> shard0, id=1 -> shard1, id=2 -> shard2, id=3 -> shard0
+    const int64_t ids[] = {0, 1, 2, 3};
     auto result = execute_distributed_dml(
         "INSERT INTO users (id, name, age) VALUES (0, 'Zero', 10), (1, 'One', 20), (2, 'Two', 30), (3, 'Three', 40)");
     EXPECT_TRUE(result.success);
     EXPECT_EQ(result.affected_rows, 4u);
     EXPECT_EQ(mock_executor.total_row_count("users"), 4u);
 
-    // shard0 should have id=0,3 (2 rows); shard1 has id=1 (1 row); shard2 has id=2 (1 row)
-    auto* s0 = mock_executor.get_backend("shard0");
-    auto* s1 = mock_executor.get_backend("shard1");
-    auto* s2 = mock_executor.get_backend("shard2");
-    EXPECT_EQ(s0->mutable_sources["users"]->row_count(), 2u);
-    EXPECT_EQ(s1->mutable_sources["users"]->row_count(), 1u);
-    EXPECT_EQ(s2->mutable_sources["users"]->row_count(), 1u);
+    size_t expected[3] = {0, 0, 0};
+    for (int64_t id : ids) expected[shard_for_id(id)]++;
+    EXPECT_EQ(row_count_on("shard0", "users"), expected[0]);
+    EXPECT_EQ(row_count_on("shard1", "users"), expected[1]);
+    EXPECT_EQ(row_count_on("shard2", "users"), expected[2]);
 }
 
 // UPDATE unsharded -> single backend
@@ -434,17 +444,19 @@ TEST_F(DistributedDmlTest, UpdateUnsharded) {
 
 // UPDATE sharded with shard key in WHERE -> single shard targeted
 TEST_F(DistributedDmlTest, UpdateShardedTargeted) {
-    // Insert a row: id=3 -> shard0
     execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
     mock_executor.clear_sql_logs();
 
     auto result = execute_distributed_dml("UPDATE users SET age = 18 WHERE id = 3");
     EXPECT_TRUE(result.success);
 
-    // Only shard0 should have received the UPDATE (3 % 3 == 0)
-    EXPECT_EQ(mock_executor.get_executed_sqls("shard0").size(), 1u);
-    EXPECT_EQ(mock_executor.get_executed_sqls("shard1").size(), 0u);
-    EXPECT_EQ(mock_executor.get_executed_sqls("shard2").size(), 0u);
+    const char* target = backend_for_id(3);
+    EXPECT_EQ(mock_executor.get_executed_sqls(target).size(), 1u);
+    for (const char* name : {"shard0", "shard1", "shard2"}) {
+        if (std::strcmp(name, target) != 0) {
+            EXPECT_EQ(mock_executor.get_executed_sqls(name).size(), 0u);
+        }
+    }
 }
 
 // UPDATE sharded without shard key -> scatter to all shards
@@ -480,10 +492,13 @@ TEST_F(DistributedDmlTest, DeleteShardedTargeted) {
     auto result = execute_distributed_dml("DELETE FROM users WHERE id = 3");
     EXPECT_TRUE(result.success);
 
-    // Only shard0 (3 % 3 == 0)
-    EXPECT_EQ(mock_executor.get_executed_sqls("shard0").size(), 1u);
-    EXPECT_EQ(mock_executor.get_executed_sqls("shard1").size(), 0u);
-    EXPECT_EQ(mock_executor.get_executed_sqls("shard2").size(), 0u);
+    const char* target = backend_for_id(3);
+    EXPECT_EQ(mock_executor.get_executed_sqls(target).size(), 1u);
+    for (const char* name : {"shard0", "shard1", "shard2"}) {
+        if (std::strcmp(name, target) != 0) {
+            EXPECT_EQ(mock_executor.get_executed_sqls(name).size(), 0u);
+        }
+    }
 }
 
 // DELETE sharded scatter -> all shards
@@ -508,14 +523,14 @@ TEST_F(DistributedDmlTest, InsertThenSelectVerify) {
     // Verify total count
     EXPECT_EQ(mock_executor.total_row_count("users"), 3u);
 
-    // Each shard should have exactly 1 row
-    EXPECT_EQ(mock_executor.get_backend("shard0")->mutable_sources["users"]->row_count(), 1u);
-    EXPECT_EQ(mock_executor.get_backend("shard1")->mutable_sources["users"]->row_count(), 1u);
-    EXPECT_EQ(mock_executor.get_backend("shard2")->mutable_sources["users"]->row_count(), 1u);
-
-    // Verify data via distributed SELECT
     auto rs = execute_distributed_select("SELECT * FROM users");
     EXPECT_EQ(rs.row_count(), 3u);
+
+    for (int64_t id : {0, 1, 2}) {
+        std::string sql = "SELECT name FROM users WHERE id = " + std::to_string(id);
+        auto point = execute_distributed_select(sql.c_str());
+        EXPECT_EQ(point.row_count(), 1u) << "point lookup missed id=" << id;
+    }
 }
 
 // ==================================================================
@@ -559,12 +574,14 @@ TEST_F(DistributedDmlTest, DmlWithCrossShardSubquery) {
     collect_and_execute_remote_scans(dist_plan, total);
     EXPECT_TRUE(total.success);
 
-    // Users 0 and 1 should be deleted; user 2 should remain
     EXPECT_EQ(mock_executor.total_row_count("users"), 1u);
-
-    // The remaining user should be Carol (id=2) on shard2
-    auto* s2 = mock_executor.get_backend("shard2");
-    EXPECT_EQ(s2->mutable_sources["users"]->row_count(), 1u);
+    auto* remaining = mock_executor.get_backend(backend_for_id(2))->mutable_sources["users"];
+    ASSERT_GE(remaining->row_count(), 1u);
+    bool found_carol = false;
+    for (size_t i = 0; i < remaining->row_count(); ++i) {
+        if (remaining->rows()[i].get(0).int_val == 2) found_carol = true;
+    }
+    EXPECT_TRUE(found_carol);
 }
 
 // UPDATE users SET age = 99 WHERE id IN (SELECT user_id FROM orders)
@@ -603,17 +620,17 @@ TEST_F(DistributedDmlTest, UpdateWithCrossShardSubquery) {
     // Total user count unchanged
     EXPECT_EQ(mock_executor.total_row_count("users"), 3u);
 
-    // Verify age updates by checking shard0 (id=0) and shard1 (id=1)
-    auto* s0 = mock_executor.get_backend("shard0");
-    auto* s1 = mock_executor.get_backend("shard1");
-    ASSERT_EQ(s0->mutable_sources["users"]->row_count(), 1u);
-    ASSERT_EQ(s1->mutable_sources["users"]->row_count(), 1u);
-    // age is column index 2
-    EXPECT_EQ(s0->mutable_sources["users"]->rows()[0].get(2).int_val, 99);
-    EXPECT_EQ(s1->mutable_sources["users"]->rows()[0].get(2).int_val, 99);
-    // Carol should be unchanged
-    auto* s2 = mock_executor.get_backend("shard2");
-    EXPECT_EQ(s2->mutable_sources["users"]->rows()[0].get(2).int_val, 17);
+    auto find_age = [&](int64_t id) -> int64_t {
+        const char* bn = backend_for_id(id);
+        auto* src = mock_executor.get_backend(bn)->mutable_sources["users"];
+        for (size_t i = 0; i < src->row_count(); ++i) {
+            if (src->rows()[i].get(0).int_val == id) return src->rows()[i].get(2).int_val;
+        }
+        return -1;
+    };
+    EXPECT_EQ(find_age(0), 99);
+    EXPECT_EQ(find_age(1), 99);
+    EXPECT_EQ(find_age(2), 17);
 }
 
 // ==================================================================
@@ -674,4 +691,82 @@ TEST_F(DistributedDmlTest, InsertSelectDistributed) {
 
     // user_archive on orders_backend should now have 3 rows
     EXPECT_EQ(mock_executor.get_backend("orders_backend")->mutable_sources["user_archive"]->row_count(), 3u);
+}
+
+TEST_F(DistributedDmlTest, InsertMissingShardKeyErrors) {
+    auto result = execute_distributed_dml("INSERT INTO users (name, age) VALUES ('Carol', 17)");
+    EXPECT_FALSE(result.success);
+    EXPECT_NE(result.error_message.find("shard key"), std::string::npos);
+    EXPECT_EQ(mock_executor.total_row_count("users"), 0u);
+}
+
+TEST_F(DistributedDmlTest, InsertNonLiteralShardKeyErrors) {
+    auto result = execute_distributed_dml(
+        "INSERT INTO users (id, name, age) VALUES (1 + 1, 'Carol', 17)");
+    EXPECT_FALSE(result.success);
+    EXPECT_NE(result.error_message.find("literal"), std::string::npos);
+    EXPECT_EQ(mock_executor.total_row_count("users"), 0u);
+}
+
+TEST_F(DistributedDmlTest, UpdateShardKeyErrors) {
+    execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
+    auto result = execute_distributed_dml("UPDATE users SET id = 9 WHERE id = 3");
+    EXPECT_FALSE(result.success);
+    EXPECT_NE(result.error_message.find("shard key"), std::string::npos);
+}
+
+TEST_F(DistributedDmlTest, InsertThenPointSelectRange) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id";
+    cfg.shards = {{"shard0"}, {"shard1"}, {"shard2"}};
+    cfg.strategy = RoutingStrategy::RANGE;
+    cfg.ranges = {{5, 0}, {10, 1}, {100000, 2}};
+    shard_map.add_table(cfg);
+
+    EXPECT_TRUE(execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Low', 1)").success);
+    EXPECT_TRUE(execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (7, 'Mid', 2)").success);
+    EXPECT_TRUE(execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (20, 'High', 3)").success);
+
+    EXPECT_EQ(row_count_on("shard0", "users"), 1u);
+    EXPECT_EQ(row_count_on("shard1", "users"), 1u);
+    EXPECT_EQ(row_count_on("shard2", "users"), 1u);
+
+    auto low = execute_distributed_select("SELECT name FROM users WHERE id = 3");
+    ASSERT_EQ(low.row_count(), 1u);
+    EXPECT_EQ(std::string(low.rows[0].get(0).str_val.ptr, low.rows[0].get(0).str_val.len), "Low");
+
+    auto mid = execute_distributed_select("SELECT name FROM users WHERE id = 7");
+    ASSERT_EQ(mid.row_count(), 1u);
+    EXPECT_EQ(std::string(mid.rows[0].get(0).str_val.ptr, mid.rows[0].get(0).str_val.len), "Mid");
+
+    auto high = execute_distributed_select("SELECT name FROM users WHERE id = 20");
+    ASSERT_EQ(high.row_count(), 1u);
+    EXPECT_EQ(std::string(high.rows[0].get(0).str_val.ptr, high.rows[0].get(0).str_val.len), "High");
+}
+
+TEST_F(DistributedDmlTest, InsertThenPointSelectList) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id";
+    cfg.shards = {{"shard0"}, {"shard1"}, {"shard2"}};
+    cfg.strategy = RoutingStrategy::LIST;
+    cfg.list = {
+        {true, 3, "", 0},
+        {true, 7, "", 1},
+        {true, 20, "", 2},
+    };
+    shard_map.add_table(cfg);
+
+    EXPECT_TRUE(execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'A', 1)").success);
+    EXPECT_TRUE(execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (7, 'B', 2)").success);
+    EXPECT_TRUE(execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (20, 'C', 3)").success);
+
+    EXPECT_EQ(row_count_on("shard0", "users"), 1u);
+    EXPECT_EQ(row_count_on("shard1", "users"), 1u);
+    EXPECT_EQ(row_count_on("shard2", "users"), 1u);
+
+    EXPECT_EQ(execute_distributed_select("SELECT name FROM users WHERE id = 3").row_count(), 1u);
+    EXPECT_EQ(execute_distributed_select("SELECT name FROM users WHERE id = 7").row_count(), 1u);
+    EXPECT_EQ(execute_distributed_select("SELECT name FROM users WHERE id = 20").row_count(), 1u);
 }

--- a/tests/test_distributed_dml.cpp
+++ b/tests/test_distributed_dml.cpp
@@ -12,6 +12,8 @@
 #include "sql_engine/in_memory_catalog.h"
 #include "sql_engine/data_source.h"
 #include "sql_engine/function_registry.h"
+#include "sql_engine/session.h"
+#include "sql_engine/local_txn.h"
 #include "sql_parser/parser.h"
 #include <cstring>
 #include <string>
@@ -305,7 +307,8 @@ protected:
             return r;
         }
 
-        DistributedPlanner<Dialect::MySQL> dist(shard_map, catalog, parser.arena());
+        DistributedPlanner<Dialect::MySQL> dist(shard_map, catalog, parser.arena(),
+                                                 &mock_executor, &functions);
         PlanNode* dist_plan = dist.distribute_dml(plan);
         if (dist.last_error()) {
             DmlResult r;
@@ -371,8 +374,10 @@ protected:
         PlanNode* plan = builder.build(pr.ast);
         if (!plan) return {};
 
-        DistributedPlanner<Dialect::MySQL> dist(shard_map, catalog, p.arena());
+        DistributedPlanner<Dialect::MySQL> dist(shard_map, catalog, p.arena(),
+                                                 &mock_executor, &functions);
         PlanNode* dist_plan = dist.distribute(plan);
+        if (dist.last_error()) return {};
 
         PlanExecutor<Dialect::MySQL> executor(functions, catalog, p.arena());
         executor.set_remote_executor(&mock_executor);
@@ -708,11 +713,88 @@ TEST_F(DistributedDmlTest, InsertNonLiteralShardKeyErrors) {
     EXPECT_EQ(mock_executor.total_row_count("users"), 0u);
 }
 
-TEST_F(DistributedDmlTest, UpdateShardKeyErrors) {
+TEST_F(DistributedDmlTest, UpdateShardKeyMovesRow) {
     execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
+    const char* src = backend_for_id(3);
+    const char* dst = backend_for_id(9);
+    ASSERT_STRNE(src, dst);
+
     auto result = execute_distributed_dml("UPDATE users SET id = 9 WHERE id = 3");
+    EXPECT_TRUE(result.success) << result.error_message;
+    EXPECT_EQ(row_count_on(src, "users"), 0u);
+    EXPECT_EQ(row_count_on(dst, "users"), 1u);
+
+    auto got = execute_distributed_select("SELECT name FROM users WHERE id = 9");
+    ASSERT_EQ(got.row_count(), 1u);
+    EXPECT_EQ(std::string(got.rows[0].get(0).str_val.ptr, got.rows[0].get(0).str_val.len),
+              "Carol");
+}
+
+TEST_F(DistributedDmlTest, UpdateShardKeySameShard) {
+    int64_t a = 3;
+    int64_t b = a;
+    for (int64_t i = 4; i < 200; ++i) {
+        if (shard_for_id(i) == shard_for_id(a)) { b = i; break; }
+    }
+    ASSERT_NE(a, b);
+
+    execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
+    auto result = execute_distributed_dml(
+        ("UPDATE users SET id = " + std::to_string(b) + " WHERE id = 3").c_str());
+    EXPECT_TRUE(result.success) << result.error_message;
+    EXPECT_EQ(row_count_on(backend_for_id(a), "users"), 1u);
+    auto got = execute_distributed_select(
+        ("SELECT id FROM users WHERE id = " + std::to_string(b)).c_str());
+    ASSERT_EQ(got.row_count(), 1u);
+}
+
+TEST_F(DistributedDmlTest, UnknownTableDmlErrors) {
+    catalog.add_table("", "ghost", {
+        {"id", SqlType::make_int(), false},
+    });
+    auto result = execute_distributed_dml("INSERT INTO ghost (id) VALUES (1)");
     EXPECT_FALSE(result.success);
-    EXPECT_NE(result.error_message.find("shard key"), std::string::npos);
+    EXPECT_NE(result.error_message.find("shard map"), std::string::npos);
+}
+
+TEST_F(DistributedDmlTest, CompositeShardKeyInsertSelect) {
+    catalog.add_table("", "kv", {
+        {"tenant_id", SqlType::make_int(), false},
+        {"id",        SqlType::make_int(), false},
+        {"name",      SqlType::make_varchar(255), true},
+    });
+    TableShardConfig cfg;
+    cfg.table_name = "kv";
+    cfg.shard_key = "tenant_id+id";
+    cfg.shards = {{"shard0"}, {"shard1"}, {"shard2"}};
+    shard_map.add_table(cfg);
+    mock_executor.add_table_to_all("kv", {
+        {"tenant_id", SqlType::make_int(), false},
+        {"id",        SqlType::make_int(), false},
+        {"name",      SqlType::make_varchar(255), true},
+    });
+
+    auto missing = execute_distributed_dml(
+        "INSERT INTO kv (id, name) VALUES (1, 'x')");
+    EXPECT_FALSE(missing.success);
+    EXPECT_NE(missing.error_message.find("shard key"), std::string::npos);
+
+    EXPECT_TRUE(execute_distributed_dml(
+        "INSERT INTO kv (tenant_id, id, name) VALUES (1, 3, 'Alice')").success);
+    EXPECT_TRUE(execute_distributed_dml(
+        "INSERT INTO kv (tenant_id, id, name) VALUES (2, 3, 'Bob')").success);
+
+    auto alice = execute_distributed_select(
+        "SELECT name FROM kv WHERE tenant_id = 1 AND id = 3");
+    ASSERT_EQ(alice.row_count(), 1u);
+    EXPECT_EQ(std::string(alice.rows[0].get(0).str_val.ptr,
+                          alice.rows[0].get(0).str_val.len), "Alice");
+
+    auto bob = execute_distributed_select(
+        "SELECT name FROM kv WHERE tenant_id = 2 AND id = 3");
+    ASSERT_EQ(bob.row_count(), 1u);
+    EXPECT_EQ(std::string(bob.rows[0].get(0).str_val.ptr,
+                          bob.rows[0].get(0).str_val.len), "Bob");
 }
 
 TEST_F(DistributedDmlTest, InsertThenPointSelectRange) {
@@ -783,4 +865,94 @@ TEST_F(DistributedDmlTest, MultiTableDeleteOnShardedFails) {
         "DELETE u FROM users u JOIN orders o ON u.id = o.user_id");
     EXPECT_FALSE(result.success);
     EXPECT_NE(result.error_message.find("sharded"), std::string::npos);
+}
+
+TEST_F(DistributedDmlTest, InsertUnmappedListValueErrors) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id";
+    cfg.shards = {{"shard0"}, {"shard1"}, {"shard2"}};
+    cfg.strategy = RoutingStrategy::LIST;
+    cfg.list = {
+        {true, 3, "", 0},
+        {true, 7, "", 1},
+    };
+    shard_map.add_table(cfg);
+
+    auto result = execute_distributed_dml(
+        "INSERT INTO users (id, name, age) VALUES (99, 'Nope', 1)");
+    EXPECT_FALSE(result.success);
+    EXPECT_NE(result.error_message.find("mapped"), std::string::npos);
+    EXPECT_EQ(mock_executor.total_row_count("users"), 0u);
+}
+
+TEST_F(DistributedDmlTest, InsertThenListBetweenSelect) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id";
+    cfg.shards = {{"shard0"}, {"shard1"}, {"shard2"}};
+    cfg.strategy = RoutingStrategy::LIST;
+    cfg.list = {
+        {true, 3, "", 0},
+        {true, 7, "", 1},
+        {true, 20, "", 2},
+    };
+    shard_map.add_table(cfg);
+
+    EXPECT_TRUE(execute_distributed_dml(
+        "INSERT INTO users (id, name, age) VALUES (3, 'A', 1)").success);
+    EXPECT_TRUE(execute_distributed_dml(
+        "INSERT INTO users (id, name, age) VALUES (7, 'B', 2)").success);
+    EXPECT_TRUE(execute_distributed_dml(
+        "INSERT INTO users (id, name, age) VALUES (20, 'C', 3)").success);
+
+    auto mid = execute_distributed_select("SELECT name FROM users WHERE id BETWEEN 6 AND 8");
+    ASSERT_EQ(mid.row_count(), 1u);
+    EXPECT_EQ(std::string(mid.rows[0].get(0).str_val.ptr, mid.rows[0].get(0).str_val.len), "B");
+}
+
+TEST_F(DistributedDmlTest, PlanCacheRedistributesSelect) {
+    execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
+    LocalTransactionManager txn(data_arena);
+    Session<Dialect::MySQL> session(catalog, txn);
+    session.set_remote_executor(&mock_executor);
+    session.set_shard_map(&shard_map);
+
+    auto first = session.execute_query("SELECT name FROM users WHERE id = 3");
+    ASSERT_EQ(first.row_count(), 1u);
+    EXPECT_EQ(session.plan_cache_size(), 1u);
+
+    auto second = session.execute_query("SELECT name FROM users WHERE id = 3");
+    ASSERT_EQ(second.row_count(), 1u);
+    EXPECT_EQ(session.plan_cache_size(), 1u);
+    EXPECT_EQ(std::string(second.rows[0].get(0).str_val.ptr,
+                          second.rows[0].get(0).str_val.len), "Carol");
+}
+
+TEST_F(DistributedDmlTest, PlanCacheSeesUpdatedShardMap) {
+    execute_distributed_dml("INSERT INTO users (id, name, age) VALUES (3, 'Carol', 17)");
+    std::string home = backend_for_id(3);
+    LocalTransactionManager txn(data_arena);
+    Session<Dialect::MySQL> session(catalog, txn);
+    session.set_remote_executor(&mock_executor);
+    session.set_shard_map(&shard_map);
+
+    const char* sql = "SELECT name FROM users WHERE id = 3";
+    ASSERT_EQ(session.execute_query(sql).row_count(), 1u);
+    EXPECT_EQ(session.plan_cache_size(), 1u);
+
+    TableShardConfig unsharded;
+    unsharded.table_name = "users";
+    unsharded.shard_key = "";
+    unsharded.shards = {{home}};
+    shard_map.add_table(unsharded);
+    mock_executor.clear_sql_logs();
+
+    auto rs = session.execute_query(sql);
+    ASSERT_EQ(rs.row_count(), 1u);
+    EXPECT_EQ(mock_executor.get_executed_sqls(home).size(), 1u);
+    for (const char* s : {"shard0", "shard1", "shard2"}) {
+        if (s != home)
+            EXPECT_EQ(mock_executor.get_executed_sqls(s).size(), 0u) << s;
+    }
 }

--- a/tests/test_distributed_dml.cpp
+++ b/tests/test_distributed_dml.cpp
@@ -770,3 +770,17 @@ TEST_F(DistributedDmlTest, InsertThenPointSelectList) {
     EXPECT_EQ(execute_distributed_select("SELECT name FROM users WHERE id = 7").row_count(), 1u);
     EXPECT_EQ(execute_distributed_select("SELECT name FROM users WHERE id = 20").row_count(), 1u);
 }
+
+TEST_F(DistributedDmlTest, MultiTableUpdateOnShardedFails) {
+    auto result = execute_distributed_dml(
+        "UPDATE users u JOIN orders o ON u.id = o.user_id SET u.age = 30");
+    EXPECT_FALSE(result.success);
+    EXPECT_NE(result.error_message.find("sharded"), std::string::npos);
+}
+
+TEST_F(DistributedDmlTest, MultiTableDeleteOnShardedFails) {
+    auto result = execute_distributed_dml(
+        "DELETE u FROM users u JOIN orders o ON u.id = o.user_id");
+    EXPECT_FALSE(result.success);
+    EXPECT_NE(result.error_message.find("sharded"), std::string::npos);
+}

--- a/tests/test_distributed_planner.cpp
+++ b/tests/test_distributed_planner.cpp
@@ -1061,3 +1061,41 @@ TEST_F(DistributedPlannerTest, RemoteSqlLenIsNotTruncated) {
         EXPECT_EQ(rs->remote_scan.remote_sql_len, remote.size());
     }
 }
+
+TEST_F(DistributedPlannerTest, HavingCountCorrectness) {
+    const char* sql = "SELECT dept, COUNT(*) FROM users GROUP BY dept HAVING COUNT(*) > 4";
+    auto local_rs = execute_local(sql);
+    auto dist_rs = execute_distributed(sql);
+    EXPECT_EQ(local_rs.row_count(), 2u);
+    EXPECT_TRUE(compare_results_unordered(local_rs, dist_rs));
+}
+
+TEST_F(DistributedPlannerTest, ColocatedJoinPushedToShards) {
+    shard_map.add_table(TableShardConfig{
+        "orders", "user_id",
+        {ShardInfo{"shard_1"}, ShardInfo{"shard_2"}, ShardInfo{"shard_3"}}
+    });
+
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT * FROM users JOIN orders ON users.id = orders.user_id";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> joins, remotes;
+    find_nodes(dist, PlanNodeType::JOIN, joins);
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    EXPECT_TRUE(joins.empty()) << "co-located join should not stay local";
+    ASSERT_FALSE(remotes.empty());
+    for (auto* rs : remotes) {
+        std::string remote(rs->remote_scan.remote_sql, rs->remote_scan.remote_sql_len);
+        EXPECT_NE(remote.find("JOIN"), std::string::npos) << remote;
+    }
+}

--- a/tests/test_distributed_planner.cpp
+++ b/tests/test_distributed_planner.cpp
@@ -874,6 +874,40 @@ TEST_F(DistributedPlannerTest, ShardRouting_RangeInequalityPrunes) {
     EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id >= 1 AND id <= 15"), 3u);
 }
 
+TEST_F(DistributedPlannerTest, ShardRouting_ListBetweenPrunes) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id";
+    cfg.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    cfg.strategy = RoutingStrategy::LIST;
+    cfg.list = {
+        {true, 1, "", 0},
+        {true, 6, "", 1},
+        {true, 7, "", 1},
+        {true, 15, "", 2},
+    };
+    shard_map.add_table(cfg);
+
+    auto count_remotes = [&](const char* sql) {
+        Parser<Dialect::MySQL> parser;
+        auto pr = parser.parse(sql, std::strlen(sql));
+        PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+        PlanNode* plan = builder.build(pr.ast);
+        DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+        PlanNode* dist = dp.distribute(plan);
+        std::vector<PlanNode*> remotes;
+        find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+        return remotes.size();
+    };
+
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id BETWEEN 6 AND 7"), 1u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id BETWEEN 1 AND 15"), 3u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id = 99"), 3u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id IN (6, 99)"), 1u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id IN (6, 15)"), 2u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id BETWEEN 2 AND 5"), 3u);
+}
+
 TEST_F(DistributedPlannerTest, ShardRouting_Correctness) {
     // The shard routing uses FNV-1a 64-bit hash of the key % num_shards
     // to pick a shard, but the test fixture uses sequential partitioning
@@ -1164,4 +1198,112 @@ TEST_F(DistributedPlannerTest, ColocatedJoinPushedToShards) {
         std::string remote(rs->remote_scan.remote_sql, rs->remote_scan.remote_sql_len);
         EXPECT_NE(remote.find("JOIN"), std::string::npos) << remote;
     }
+}
+
+TEST_F(DistributedPlannerTest, CompositeColocatedJoinPushedToShards) {
+    catalog.add_table("", "kv", {
+        {"tenant_id", SqlType::make_int(), false},
+        {"id",        SqlType::make_int(), false},
+        {"name",      SqlType::make_varchar(255), true},
+    });
+    catalog.add_table("", "kv_orders", {
+        {"tenant_id", SqlType::make_int(), false},
+        {"id",        SqlType::make_int(), false},
+        {"amt",       SqlType::make_int(), true},
+    });
+    TableShardConfig kv;
+    kv.table_name = "kv";
+    kv.shard_key = "tenant_id+id";
+    kv.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    shard_map.add_table(kv);
+    TableShardConfig kvo;
+    kvo.table_name = "kv_orders";
+    kvo.shard_key = "tenant_id+id";
+    kvo.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    shard_map.add_table(kvo);
+
+    Parser<Dialect::MySQL> parser;
+    const char* sql =
+        "SELECT * FROM kv JOIN kv_orders ON kv.tenant_id = kv_orders.tenant_id "
+        "AND kv.id = kv_orders.id";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> joins, remotes;
+    find_nodes(dist, PlanNodeType::JOIN, joins);
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    EXPECT_TRUE(joins.empty()) << "composite co-located join should not stay local";
+    ASSERT_EQ(remotes.size(), 3u);
+    for (auto* rs : remotes) {
+        std::string remote(rs->remote_scan.remote_sql, rs->remote_scan.remote_sql_len);
+        EXPECT_NE(remote.find("JOIN"), std::string::npos) << remote;
+    }
+}
+
+TEST_F(DistributedPlannerTest, IncompleteCompositeJoinStaysLocal) {
+    catalog.add_table("", "kv", {
+        {"tenant_id", SqlType::make_int(), false},
+        {"id",        SqlType::make_int(), false},
+        {"name",      SqlType::make_varchar(255), true},
+    });
+    catalog.add_table("", "kv_orders", {
+        {"tenant_id", SqlType::make_int(), false},
+        {"id",        SqlType::make_int(), false},
+        {"amt",       SqlType::make_int(), true},
+    });
+    TableShardConfig kv;
+    kv.table_name = "kv";
+    kv.shard_key = "tenant_id+id";
+    kv.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    shard_map.add_table(kv);
+    TableShardConfig kvo;
+    kvo.table_name = "kv_orders";
+    kvo.shard_key = "tenant_id+id";
+    kvo.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    shard_map.add_table(kvo);
+
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT * FROM kv JOIN kv_orders ON kv.tenant_id = kv_orders.tenant_id";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> joins;
+    find_nodes(dist, PlanNodeType::JOIN, joins);
+    EXPECT_FALSE(joins.empty()) << "join on a partial composite key must gather";
+}
+
+TEST_F(DistributedPlannerTest, UnknownTableErrors) {
+    catalog.add_table("", "ghost", {
+        {"id", SqlType::make_int(), false},
+    });
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT * FROM ghost";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    EXPECT_EQ(dist, nullptr);
+    ASSERT_NE(dp.last_error(), nullptr);
+    EXPECT_NE(std::string(dp.last_error()).find("shard map"), std::string::npos);
 }

--- a/tests/test_distributed_planner.cpp
+++ b/tests/test_distributed_planner.cpp
@@ -1288,6 +1288,57 @@ TEST_F(DistributedPlannerTest, IncompleteCompositeJoinStaysLocal) {
     EXPECT_FALSE(joins.empty()) << "join on a partial composite key must gather";
 }
 
+TEST_F(DistributedPlannerTest, CompositeRangePrunesOnFirstKey) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id+name";
+    cfg.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    cfg.strategy = RoutingStrategy::RANGE;
+    cfg.ranges = {{5, 0}, {10, 1}, {100000, 2}};
+    shard_map.add_table(cfg);
+
+    auto count_remotes = [&](const char* sql) {
+        Parser<Dialect::MySQL> parser;
+        auto pr = parser.parse(sql, std::strlen(sql));
+        PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+        PlanNode* plan = builder.build(pr.ast);
+        DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+        PlanNode* dist = dp.distribute(plan);
+        std::vector<PlanNode*> remotes;
+        find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+        return remotes.size();
+    };
+
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id <= 5"), 1u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id BETWEEN 6 AND 10"), 1u);
+}
+
+TEST_F(DistributedPlannerTest, SemiJoinPrunesProbeShards) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT * FROM users JOIN orders ON users.id = orders.user_id";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena(),
+                                          &mock_executor, &functions);
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> remotes;
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    bool saw_users_in = false;
+    for (auto* rs : remotes) {
+        std::string remote(rs->remote_scan.remote_sql, rs->remote_scan.remote_sql_len);
+        if (remote.find("users") != std::string::npos &&
+            remote.find("IN") != std::string::npos)
+            saw_users_in = true;
+    }
+    EXPECT_TRUE(saw_users_in) << "semi-join should push IN on the sharded probe";
+}
+
 TEST_F(DistributedPlannerTest, UnknownTableErrors) {
     catalog.add_table("", "ghost", {
         {"id", SqlType::make_int(), false},

--- a/tests/test_distributed_planner.cpp
+++ b/tests/test_distributed_planner.cpp
@@ -390,6 +390,10 @@ protected:
                 find_nodes(node->merge_sort.children[i], type, out);
             return;
         }
+        if (node->type == PlanNodeType::DERIVED_SCAN) {
+            find_nodes(node->derived_scan.inner_plan, type, out);
+            return;
+        }
         find_nodes(node->left, type, out);
         find_nodes(node->right, type, out);
     }
@@ -963,4 +967,97 @@ TEST_F(DistributedPlannerTest, WindowGatherCorrectness) {
     EXPECT_EQ(local_rs.row_count(), 15u);
     EXPECT_EQ(dist_rs.row_count(), 15u);
     EXPECT_TRUE(compare_results_unordered(local_rs, dist_rs));
+}
+
+TEST_F(DistributedPlannerTest, DerivedScanIsDistributed) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT name FROM (SELECT name, age FROM users WHERE age > 20) AS t";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> scans, remotes;
+    find_nodes(dist, PlanNodeType::SCAN, scans);
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    EXPECT_TRUE(scans.empty()) << "inner SCAN must be rewritten";
+    EXPECT_FALSE(remotes.empty());
+}
+
+TEST_F(DistributedPlannerTest, DerivedScanCorrectness) {
+    const char* sql = "SELECT name FROM (SELECT name, age FROM users WHERE age > 20) AS t";
+    auto local_rs = execute_local(sql);
+    auto dist_rs = execute_distributed(sql);
+    EXPECT_GT(local_rs.row_count(), 0u);
+    EXPECT_EQ(local_rs.row_count(), dist_rs.row_count());
+    EXPECT_TRUE(compare_results_unordered(local_rs, dist_rs));
+}
+
+TEST_F(DistributedPlannerTest, OrderByExpressionDoesNotMergeOnColumnZero) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT name, age FROM users ORDER BY age + 1";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> merges;
+    find_nodes(dist, PlanNodeType::MERGE_SORT, merges);
+    EXPECT_TRUE(merges.empty()) << "expression ORDER BY must not MERGE_SORT on col 0";
+
+    auto local_rs = execute_local(sql);
+    auto dist_rs = execute_distributed(sql);
+    EXPECT_EQ(local_rs.row_count(), dist_rs.row_count());
+    EXPECT_TRUE(compare_results_ordered(local_rs, dist_rs));
+}
+
+TEST_F(DistributedPlannerTest, OrderByAliasAndPositionCorrectness) {
+    const char* sql = "SELECT name AS n, age AS a FROM users ORDER BY a DESC";
+    auto local_rs = execute_local(sql);
+    auto dist_rs = execute_distributed(sql);
+    EXPECT_EQ(local_rs.row_count(), 15u);
+    EXPECT_TRUE(compare_results_ordered(local_rs, dist_rs));
+
+    const char* sql2 = "SELECT name, age FROM users ORDER BY 2 DESC";
+    auto local2 = execute_local(sql2);
+    auto dist2 = execute_distributed(sql2);
+    EXPECT_TRUE(compare_results_ordered(local2, dist2));
+}
+
+TEST_F(DistributedPlannerTest, RemoteSqlLenIsNotTruncated) {
+    std::string name(70000, 'x');
+    std::string sql = "SELECT * FROM users WHERE name = '" + name + "'";
+    Parser<Dialect::MySQL> parser;
+    auto pr = parser.parse(sql.c_str(), sql.size());
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> remotes;
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    ASSERT_FALSE(remotes.empty());
+    for (auto* rs : remotes) {
+        EXPECT_GT(rs->remote_scan.remote_sql_len, 65535u);
+        std::string remote(rs->remote_scan.remote_sql, rs->remote_scan.remote_sql_len);
+        EXPECT_NE(remote.find(name), std::string::npos);
+        EXPECT_EQ(rs->remote_scan.remote_sql_len, remote.size());
+    }
 }

--- a/tests/test_distributed_planner.cpp
+++ b/tests/test_distributed_planner.cpp
@@ -808,6 +808,72 @@ TEST_F(DistributedPlannerTest, ShardRouting_NoShardKey_AllShards) {
         << "Non-shard-key filter should query all shards";
 }
 
+TEST_F(DistributedPlannerTest, ShardRouting_OrOfEqualitiesPrunesUnion) {
+    Parser<Dialect::MySQL> parser;
+    auto pr = parser.parse("SELECT * FROM users WHERE id = 4 OR id = 4", 42);
+    ASSERT_EQ(pr.status, ParseResult::OK);
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    std::vector<PlanNode*> remotes;
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    EXPECT_EQ(remotes.size(), 1u);
+}
+
+TEST_F(DistributedPlannerTest, ShardRouting_OrWithNonKeyScatters) {
+    Parser<Dialect::MySQL> parser;
+    auto pr = parser.parse("SELECT * FROM users WHERE id = 4 OR age > 20", 45);
+    ASSERT_EQ(pr.status, ParseResult::OK);
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    std::vector<PlanNode*> remotes;
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    EXPECT_EQ(remotes.size(), 3u);
+}
+
+TEST_F(DistributedPlannerTest, ShardRouting_PlaceholderScatters) {
+    Parser<Dialect::MySQL> parser;
+    auto pr = parser.parse("SELECT * FROM users WHERE id = ?", 32);
+    ASSERT_EQ(pr.status, ParseResult::OK);
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    std::vector<PlanNode*> remotes;
+    find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+    EXPECT_EQ(remotes.size(), 3u);
+}
+
+TEST_F(DistributedPlannerTest, ShardRouting_RangeInequalityPrunes) {
+    TableShardConfig cfg;
+    cfg.table_name = "users";
+    cfg.shard_key = "id";
+    cfg.shards = {{"shard_1"}, {"shard_2"}, {"shard_3"}};
+    cfg.strategy = RoutingStrategy::RANGE;
+    cfg.ranges = {{5, 0}, {10, 1}, {100000, 2}};
+    shard_map.add_table(cfg);
+
+    auto count_remotes = [&](const char* sql) {
+        Parser<Dialect::MySQL> parser;
+        auto pr = parser.parse(sql, std::strlen(sql));
+        PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+        PlanNode* plan = builder.build(pr.ast);
+        DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+        PlanNode* dist = dp.distribute(plan);
+        std::vector<PlanNode*> remotes;
+        find_nodes(dist, PlanNodeType::REMOTE_SCAN, remotes);
+        return remotes.size();
+    };
+
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id <= 5"), 1u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id > 10"), 1u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id BETWEEN 6 AND 10"), 1u);
+    EXPECT_EQ(count_remotes("SELECT * FROM users WHERE id >= 1 AND id <= 15"), 3u);
+}
+
 TEST_F(DistributedPlannerTest, ShardRouting_Correctness) {
     // The shard routing uses FNV-1a 64-bit hash of the key % num_shards
     // to pick a shard, but the test fixture uses sequential partitioning

--- a/tests/test_distributed_planner.cpp
+++ b/tests/test_distributed_planner.cpp
@@ -849,3 +849,118 @@ TEST_F(DistributedPlannerTest, ShardMap_IndexForInt) {
     EXPECT_EQ(idx1, idx2);
     EXPECT_LT(idx1, 3u);
 }
+
+TEST_F(DistributedPlannerTest, CountDistinctIsNotTwoPhaseMerge) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT COUNT(DISTINCT dept) FROM users";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    const AstNode* items = nullptr;
+    for (const AstNode* c = pr.ast->first_child; c; c = c->next_sibling) {
+        if (c->type == NodeType::NODE_SELECT_ITEM_LIST) items = c;
+    }
+    ASSERT_NE(items, nullptr);
+    ASSERT_NE(items->first_child, nullptr);
+    const AstNode* count_expr = items->first_child->first_child;
+    ASSERT_NE(count_expr, nullptr);
+    EXPECT_EQ(count_expr->type, NodeType::NODE_FUNCTION_CALL);
+    EXPECT_NE(static_cast<unsigned>(count_expr->flags & FLAG_FUNC_DISTINCT), 0u);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+    if (plan->type == PlanNodeType::PROJECT && plan->project.count > 0) {
+        EXPECT_NE(static_cast<unsigned>(plan->project.exprs[0]->flags & FLAG_FUNC_DISTINCT), 0u);
+    }
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> merges;
+    find_nodes(dist, PlanNodeType::MERGE_AGGREGATE, merges);
+    EXPECT_TRUE(merges.empty()) << "COUNT(DISTINCT) must not use SUM_OF_COUNTS merge";
+}
+
+TEST_F(DistributedPlannerTest, CountDistinctCorrectness) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT COUNT(DISTINCT dept) FROM users";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+    ASSERT_EQ(dist->type, PlanNodeType::AGGREGATE);
+    ASSERT_EQ(dist->aggregate.agg_count, 1u);
+    EXPECT_NE(static_cast<unsigned>(dist->aggregate.agg_exprs[0]->flags & FLAG_FUNC_DISTINCT), 0u);
+
+    auto local_rs = execute_local("SELECT COUNT(DISTINCT dept) FROM users");
+    auto dist_rs = execute_distributed("SELECT COUNT(DISTINCT dept) FROM users");
+    EXPECT_EQ(local_rs.row_count(), 1u);
+    EXPECT_EQ(dist_rs.row_count(), 1u);
+    EXPECT_TRUE(compare_results_unordered(local_rs, dist_rs));
+    ASSERT_GE(dist_rs.row_count(), 1u);
+    EXPECT_EQ(dist_rs.rows[0].get(0).int_val, 3);
+}
+
+TEST_F(DistributedPlannerTest, GroupByHavingKeepsFilter) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT dept, COUNT(*) FROM users GROUP BY dept HAVING COUNT(*) > 4 ORDER BY dept";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> filters, sorts, merges;
+    find_nodes(dist, PlanNodeType::FILTER, filters);
+    find_nodes(dist, PlanNodeType::SORT, sorts);
+    find_nodes(dist, PlanNodeType::MERGE_AGGREGATE, merges);
+    EXPECT_FALSE(filters.empty()) << "HAVING filter must be kept";
+    EXPECT_FALSE(sorts.empty()) << "ORDER BY must be kept";
+    EXPECT_FALSE(merges.empty());
+}
+
+TEST_F(DistributedPlannerTest, GroupByOrderByCorrectness) {
+    const char* sql = "SELECT dept, COUNT(*) FROM users GROUP BY dept ORDER BY dept";
+    auto local_rs = execute_local(sql);
+    auto dist_rs = execute_distributed(sql);
+    EXPECT_EQ(local_rs.row_count(), 3u);
+    EXPECT_TRUE(compare_results_ordered(local_rs, dist_rs));
+}
+
+TEST_F(DistributedPlannerTest, WindowNotDroppedByOrderBy) {
+    Parser<Dialect::MySQL> parser;
+    const char* sql = "SELECT name, ROW_NUMBER() OVER (ORDER BY age) AS rn FROM users ORDER BY name";
+    auto pr = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(pr.status, ParseResult::OK);
+
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(pr.ast);
+    ASSERT_NE(plan, nullptr);
+
+    DistributedPlanner<Dialect::MySQL> dp(shard_map, catalog, parser.arena());
+    PlanNode* dist = dp.distribute(plan);
+    ASSERT_NE(dist, nullptr);
+
+    std::vector<PlanNode*> windows;
+    find_nodes(dist, PlanNodeType::WINDOW, windows);
+    EXPECT_FALSE(windows.empty()) << "WINDOW node must survive ORDER BY distribution";
+}
+
+TEST_F(DistributedPlannerTest, WindowGatherCorrectness) {
+    const char* sql = "SELECT name, ROW_NUMBER() OVER (ORDER BY age) AS rn FROM users";
+    auto local_rs = execute_local(sql);
+    auto dist_rs = execute_distributed(sql);
+    EXPECT_EQ(local_rs.row_count(), 15u);
+    EXPECT_EQ(dist_rs.row_count(), 15u);
+    EXPECT_TRUE(compare_results_unordered(local_rs, dist_rs));
+}

--- a/tests/test_distributed_real.cpp
+++ b/tests/test_distributed_real.cpp
@@ -17,6 +17,7 @@
 #include "sql_engine/function_registry.h"
 #include "sql_engine/session.h"
 #include "sql_engine/local_txn.h"
+#include "sql_engine/distributed_txn.h"
 #include "sql_parser/parser.h"
 
 #include <mysql/mysql.h>
@@ -363,6 +364,94 @@ TEST_F(LiveShardedWriteTest, InsertThenPointSelect) {
 
     session.execute_statement("DELETE FROM shard_write_t WHERE id = 3");
     session.execute_statement("DELETE FROM shard_write_t WHERE id = 9");
+}
+
+bool pg_port_available(uint16_t port) {
+    std::string conninfo = std::string("host=127.0.0.1 port=") + std::to_string(port)
+        + " user=postgres password=test dbname=testdb connect_timeout=2";
+    PGconn* conn = PQconnectdb(conninfo.c_str());
+    bool ok = (PQstatus(conn) == CONNECTION_OK);
+    PQfinish(conn);
+    return ok;
+}
+
+TEST(LivePgShardedWriteTest, RangeListAndTwoPhaseCommit) {
+    if (!pg_port_available(16432) || !pg_port_available(16433)) {
+        GTEST_SKIP() << "Need PG on 16432 and 16433 (start_pg_sharding_demo.sh)";
+    }
+
+    MultiRemoteExecutor exec;
+    BackendConfig p1;
+    p1.name = "pg1";
+    p1.host = "127.0.0.1";
+    p1.port = 16432;
+    p1.user = "postgres";
+    p1.password = "test";
+    p1.database = "testdb";
+    p1.dialect = Dialect::PostgreSQL;
+    BackendConfig p2 = p1;
+    p2.name = "pg2";
+    p2.port = 16433;
+    exec.add_backend(p1);
+    exec.add_backend(p2);
+
+    InMemoryCatalog catalog;
+    catalog.add_table("", "users", {
+        {"id",   SqlType::make_int(), false},
+        {"name", SqlType::make_varchar(255), true},
+        {"age",  SqlType::make_int(), true},
+    });
+    catalog.add_table("", "regions", {
+        {"name", SqlType::make_varchar(64), false},
+        {"tz",   SqlType::make_varchar(32), true},
+    });
+
+    ShardMap shards;
+    TableShardConfig users;
+    users.table_name = "users";
+    users.shard_key = "id";
+    users.shards = {{"pg1"}, {"pg2"}};
+    users.strategy = RoutingStrategy::RANGE;
+    users.ranges = {{5, 0}, {100000, 1}};
+    shards.add_table(users);
+    TableShardConfig regions;
+    regions.table_name = "regions";
+    regions.shard_key = "name";
+    regions.shards = {{"pg1"}, {"pg2"}};
+    regions.strategy = RoutingStrategy::LIST;
+    regions.list = {
+        {false, 0, "us-east", 0},
+        {false, 0, "us-west", 1},
+    };
+    shards.add_table(regions);
+
+    Arena txn_arena{65536, 1048576};
+    DistributedTransactionManager txn(
+        exec, DistributedTransactionManager::BackendDialect::POSTGRESQL);
+    Session<Dialect::PostgreSQL> session(catalog, txn);
+    session.set_remote_executor(&exec);
+    session.set_shard_map(&shards);
+
+    auto east = session.execute_query("SELECT tz FROM regions WHERE name = 'us-east'");
+    auto west = session.execute_query("SELECT tz FROM regions WHERE name = 'us-west'");
+    ASSERT_EQ(east.row_count(), 1u);
+    ASSERT_EQ(west.row_count(), 1u);
+
+    EXPECT_TRUE(session.begin());
+    auto i0 = session.execute_statement(
+        "INSERT INTO users (id, name, age) VALUES (0, 'Zero', 1)");
+    auto i11 = session.execute_statement(
+        "INSERT INTO users (id, name, age) VALUES (11, 'Eleven', 2)");
+    EXPECT_TRUE(i0.success) << i0.error_message;
+    EXPECT_TRUE(i11.success) << i11.error_message;
+    EXPECT_TRUE(session.commit());
+
+    auto back = session.execute_query("SELECT name FROM users WHERE id IN (0, 11)");
+    EXPECT_EQ(back.row_count(), 2u);
+
+    session.execute_statement("DELETE FROM users WHERE id = 0");
+    session.execute_statement("DELETE FROM users WHERE id = 11");
+    exec.disconnect_all();
 }
 
 } // namespace

--- a/tests/test_distributed_real.cpp
+++ b/tests/test_distributed_real.cpp
@@ -15,6 +15,8 @@
 #include "sql_engine/shard_map.h"
 #include "sql_engine/in_memory_catalog.h"
 #include "sql_engine/function_registry.h"
+#include "sql_engine/session.h"
+#include "sql_engine/local_txn.h"
 #include "sql_parser/parser.h"
 
 #include <mysql/mysql.h>
@@ -270,6 +272,97 @@ TEST_F(MultiExecutorTest, UnknownBackendReturnsEmpty) {
     sql_parser::StringRef sql{"SELECT 1", 8};
     auto rs = exec_->execute("unknown", sql);
     EXPECT_TRUE(rs.empty());
+}
+
+static bool mysql_port_available(uint16_t port) {
+    MYSQL* conn = mysql_init(nullptr);
+    if (!conn) return false;
+    unsigned int timeout = 2;
+    mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &timeout);
+    bool ok = mysql_real_connect(conn, "127.0.0.1", "root", "test",
+                                  "testdb", port, nullptr, 0) != nullptr;
+    mysql_close(conn);
+    return ok;
+}
+
+class LiveShardedWriteTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        exec_ = std::make_unique<MultiRemoteExecutor>();
+        BackendConfig s1;
+        s1.name = "shard1";
+        s1.host = "127.0.0.1";
+        s1.port = 13306;
+        s1.user = "root";
+        s1.password = "test";
+        s1.database = "testdb";
+        s1.dialect = Dialect::MySQL;
+        BackendConfig s2 = s1;
+        s2.name = "shard2";
+        s2.port = 13307;
+        exec_->add_backend(s1);
+        exec_->add_backend(s2);
+
+        catalog_.add_table("", "shard_write_t", {
+            {"id",   SqlType::make_int(),        false},
+            {"name", SqlType::make_varchar(64),  true},
+        });
+
+        TableShardConfig cfg;
+        cfg.table_name = "shard_write_t";
+        cfg.shard_key = "id";
+        cfg.shards = {{"shard1"}, {"shard2"}};
+        cfg.strategy = RoutingStrategy::RANGE;
+        cfg.ranges = {{5, 0}, {100000, 1}};
+        shard_map_.add_table(cfg);
+    }
+
+    void TearDown() override {
+        if (exec_) exec_->disconnect_all();
+    }
+
+    std::unique_ptr<MultiRemoteExecutor> exec_;
+    InMemoryCatalog catalog_;
+    ShardMap shard_map_;
+};
+
+TEST_F(LiveShardedWriteTest, InsertThenPointSelect) {
+    if (!mysql_port_available(13306) || !mysql_port_available(13307)) {
+        GTEST_SKIP() << "Need MySQL on 13306 and 13307 (start_sharding_demo.sh)";
+    }
+
+    const char* ddl =
+        "CREATE TABLE IF NOT EXISTS shard_write_t (id INT PRIMARY KEY, name VARCHAR(64))";
+    StringRef ddl_ref{ddl, static_cast<uint32_t>(std::strlen(ddl))};
+    exec_->execute_dml("shard1", ddl_ref);
+    exec_->execute_dml("shard2", ddl_ref);
+    const char* wipe = "DELETE FROM shard_write_t";
+    StringRef wipe_ref{wipe, static_cast<uint32_t>(std::strlen(wipe))};
+    exec_->execute_dml("shard1", wipe_ref);
+    exec_->execute_dml("shard2", wipe_ref);
+
+    Arena txn_arena{65536, 1048576};
+    LocalTransactionManager txn(txn_arena);
+    Session<Dialect::MySQL> session(catalog_, txn);
+    session.set_remote_executor(exec_.get());
+    session.set_shard_map(&shard_map_);
+
+    auto ins1 = session.execute_statement(
+        "INSERT INTO shard_write_t (id, name) VALUES (3, 'low')");
+    auto ins2 = session.execute_statement(
+        "INSERT INTO shard_write_t (id, name) VALUES (9, 'high')");
+    EXPECT_TRUE(ins1.success) << ins1.error_message;
+    EXPECT_TRUE(ins2.success) << ins2.error_message;
+
+    auto low = session.execute_query("SELECT name FROM shard_write_t WHERE id = 3");
+    auto high = session.execute_query("SELECT name FROM shard_write_t WHERE id = 9");
+    ASSERT_EQ(low.row_count(), 1u);
+    ASSERT_EQ(high.row_count(), 1u);
+    EXPECT_EQ(std::string(low.rows[0].get(0).str_val.ptr, low.rows[0].get(0).str_val.len), "low");
+    EXPECT_EQ(std::string(high.rows[0].get(0).str_val.ptr, high.rows[0].get(0).str_val.len), "high");
+
+    session.execute_statement("DELETE FROM shard_write_t WHERE id = 3");
+    session.execute_statement("DELETE FROM shard_write_t WHERE id = 9");
 }
 
 } // namespace

--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -301,6 +301,15 @@ TEST_F(ExpressionTest, FunctionCall) {
     EXPECT_EQ(node->first_child->type, NodeType::NODE_ASTERISK);
 }
 
+TEST_F(ExpressionTest, FunctionCallDistinct) {
+    AstNode* node = parse_expr("COUNT(DISTINCT dept)");
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->type, NodeType::NODE_FUNCTION_CALL);
+    EXPECT_NE(static_cast<unsigned>(node->flags & FLAG_FUNC_DISTINCT), 0u);
+    ASSERT_NE(node->first_child, nullptr);
+    EXPECT_EQ(node->first_child->type, NodeType::NODE_COLUMN_REF);
+}
+
 TEST_F(ExpressionTest, FunctionCallMultiArg) {
     AstNode* node = parse_expr("COALESCE(a, b, 0)");
     ASSERT_NE(node, nullptr);

--- a/tests/test_operators.cpp
+++ b/tests/test_operators.cpp
@@ -1001,6 +1001,26 @@ TEST_F(SetOpOpTest, UnionAll) {
     setop.close();
 }
 
+TEST_F(SetOpOpTest, UnionAllNary) {
+    std::vector<Row> a = {build_row(arena, {value_int(1)})};
+    std::vector<Row> b = {build_row(arena, {value_int(2)})};
+    std::vector<Row> c = {build_row(arena, {value_int(3)})};
+    InMemoryDataSource ds_a(table, a);
+    InMemoryDataSource ds_b(table, b);
+    InMemoryDataSource ds_c(table, c);
+    ScanOperator scan_a(&ds_a);
+    ScanOperator scan_b(&ds_b);
+    ScanOperator scan_c(&ds_c);
+
+    SetOpOperator setop({&scan_a, &scan_b, &scan_c});
+    setop.open();
+    Row out{};
+    int count = 0;
+    while (setop.next(out)) count++;
+    EXPECT_EQ(count, 3);
+    setop.close();
+}
+
 // Regression test for silent column-count mismatch in set operations.
 // Before the validation fix, SetOpOperator::row_key would iterate each row's
 // own column_count, producing truncated/misaligned keys and silently-wrong

--- a/tests/test_pgsql_executor.cpp
+++ b/tests/test_pgsql_executor.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "sql_engine/pgsql_remote_executor.h"
+#include "sql_engine/thread_safe_executor.h"
 #include "sql_engine/backend_config.h"
 
 #include <libpq-fe.h>
@@ -225,6 +226,15 @@ TEST_F(PgSQLExecutorTest, DateType) {
     auto rs = exec_->execute("test_pgsql", sql);
     ASSERT_EQ(rs.row_count(), 1u);
     EXPECT_EQ(rs.rows[0].get(0).tag, sql_engine::Value::TAG_DATE);
+}
+
+TEST(ThreadSafePgTest, PooledSelect) {
+    SKIP_IF_NO_PGSQL();
+    sql_engine::ThreadSafeMultiRemoteExecutor exec;
+    exec.add_backend(make_pgsql_config("pool_pg"));
+    sql_parser::StringRef sql{"SELECT 1", 8};
+    auto rs = exec.execute("pool_pg", sql);
+    EXPECT_EQ(rs.row_count(), 1u);
 }
 
 } // namespace

--- a/tests/test_plan_executor.cpp
+++ b/tests/test_plan_executor.cpp
@@ -147,6 +147,16 @@ TEST_F(PlanExecutorTest, SelectDistinctDept) {
     EXPECT_EQ(depts.size(), 2u);
 }
 
+TEST_F(PlanExecutorTest, OrderByAliasAndPosition) {
+    auto by_alias = run_query("SELECT name AS n, age AS a FROM users ORDER BY a DESC");
+    ASSERT_EQ(by_alias.row_count(), 5u);
+    EXPECT_EQ(by_alias.rows[0].get(1).int_val, 35);
+
+    auto by_pos = run_query("SELECT name, age FROM users ORDER BY 2 DESC");
+    ASSERT_EQ(by_pos.row_count(), 5u);
+    EXPECT_EQ(by_pos.rows[0].get(1).int_val, 35);
+}
+
 TEST_F(PlanExecutorTest, CountDistinctDept) {
     parser.reset();
     const char* sql = "SELECT COUNT(DISTINCT dept) FROM users";

--- a/tests/test_plan_executor.cpp
+++ b/tests/test_plan_executor.cpp
@@ -177,6 +177,13 @@ TEST_F(PlanExecutorTest, CountDistinctDept) {
     EXPECT_EQ(rs.rows[0].get(0).int_val, 2);
 }
 
+TEST_F(PlanExecutorTest, HavingCountFilter) {
+    auto rs = run_query("SELECT dept, COUNT(*) FROM users GROUP BY dept HAVING COUNT(*) > 2");
+    ASSERT_EQ(rs.row_count(), 1u);
+    EXPECT_EQ(std::string(rs.rows[0].get(0).str_val.ptr, rs.rows[0].get(0).str_val.len),
+              "Engineering");
+}
+
 // SELECT name FROM users WHERE name LIKE 'A%' → LIKE filter
 TEST_F(PlanExecutorTest, SelectWithLike) {
     auto rs = run_query("SELECT name FROM users WHERE name LIKE 'A%'");

--- a/tests/test_plan_executor.cpp
+++ b/tests/test_plan_executor.cpp
@@ -147,6 +147,26 @@ TEST_F(PlanExecutorTest, SelectDistinctDept) {
     EXPECT_EQ(depts.size(), 2u);
 }
 
+TEST_F(PlanExecutorTest, CountDistinctDept) {
+    parser.reset();
+    const char* sql = "SELECT COUNT(DISTINCT dept) FROM users";
+    auto r = parser.parse(sql, std::strlen(sql));
+    ASSERT_EQ(r.status, ParseResult::OK);
+    PlanBuilder<Dialect::MySQL> builder(catalog, parser.arena());
+    PlanNode* plan = builder.build(r.ast);
+    ASSERT_NE(plan, nullptr);
+    ASSERT_EQ(plan->type, PlanNodeType::PROJECT);
+    ASSERT_GE(plan->project.count, 1u);
+    EXPECT_EQ(plan->project.exprs[0]->type, NodeType::NODE_FUNCTION_CALL);
+    EXPECT_NE(static_cast<unsigned>(plan->project.exprs[0]->flags & FLAG_FUNC_DISTINCT), 0u);
+
+    PlanExecutor<Dialect::MySQL> executor(functions, catalog, parser.arena());
+    executor.add_data_source("users", users_source);
+    auto rs = executor.execute(plan);
+    ASSERT_EQ(rs.row_count(), 1u);
+    EXPECT_EQ(rs.rows[0].get(0).int_val, 2);
+}
+
 // SELECT name FROM users WHERE name LIKE 'A%' → LIKE filter
 TEST_F(PlanExecutorTest, SelectWithLike) {
     auto rs = run_query("SELECT name FROM users WHERE name LIKE 'A%'");

--- a/tests/test_shard_map.cpp
+++ b/tests/test_shard_map.cpp
@@ -179,13 +179,36 @@ TEST(ShardMapListTest, IntKeysRouteByExplicitMap) {
     EXPECT_EQ(map.shard_index_for_int(sref("users"), 7), 1u);
 }
 
-TEST(ShardMapListTest, MissingKeyRoutesToShardZero) {
+TEST(ShardMapListTest, MissingKeyIsUnroutable) {
     TableShardConfig cfg = make_two_shards(RoutingStrategy::LIST);
     cfg.list = {ShardListEntry{true, 1, "", 0}};
     ShardMap map;
     map.add_table(cfg);
 
-    EXPECT_EQ(map.shard_index_for_int(sref("users"), 999), 0u);
+    size_t idx = 99;
+    EXPECT_FALSE(map.try_shard_index_for_int(sref("users"), 999, idx));
+}
+
+TEST(ShardMapListTest, BetweenCollectsMappedInts) {
+    TableShardConfig cfg = make_two_shards(RoutingStrategy::LIST);
+    cfg.list = {
+        ShardListEntry{true, 1, "", 0},
+        ShardListEntry{true, 6, "", 1},
+        ShardListEntry{true, 7, "", 1},
+        ShardListEntry{true, 20, "", 0},
+    };
+    ShardMap map;
+    map.add_table(cfg);
+
+    std::vector<size_t> mid;
+    map.collect_int_list_shards(sref("users"), 5, 10, mid);
+    ASSERT_EQ(mid.size(), 2u);
+    EXPECT_EQ(mid[0], 1u);
+    EXPECT_EQ(mid[1], 1u);
+
+    std::vector<size_t> none;
+    map.collect_int_list_shards(sref("users"), 2, 5, none);
+    EXPECT_TRUE(none.empty());
 }
 
 TEST(ShardMapListTest, StringKeysRouteByExplicitMap) {
@@ -199,7 +222,8 @@ TEST(ShardMapListTest, StringKeysRouteByExplicitMap) {
 
     EXPECT_EQ(map.shard_index_for_string(sref("users"), "us-east", 7), 0u);
     EXPECT_EQ(map.shard_index_for_string(sref("users"), "us-west", 7), 1u);
-    EXPECT_EQ(map.shard_index_for_string(sref("users"), "eu-north", 8), 0u);
+    size_t miss = 99;
+    EXPECT_FALSE(map.try_shard_index_for_string(sref("users"), "eu-north", 8, miss));
 }
 
 // ----------------------------------------------------------------------
@@ -225,8 +249,32 @@ TEST(ShardMapTest, ClampOnOutOfRangeShardIndex) {
     EXPECT_EQ(map.shard_index_for_int(sref("users"), 50), 1u);
 }
 
-TEST(ShardMapTest, UnknownTableReturnsZero) {
-    ShardMap map;  // empty
-    EXPECT_EQ(map.shard_index_for_int(sref("nope"), 5), 0u);
-    EXPECT_EQ(map.shard_index_for_string(sref("nope"), "x", 1), 0u);
+TEST(ShardMapTest, UnknownTableIsUnroutable) {
+    ShardMap map;
+    size_t idx = 99;
+    EXPECT_FALSE(map.try_shard_index_for_int(sref("nope"), 5, idx));
+    EXPECT_FALSE(map.try_shard_index_for_string(sref("nope"), "x", 1, idx));
+}
+
+TEST(ShardMapTest, CompositeHashIsDeterministicAndDiffersFromSingle) {
+    TableShardConfig cfg;
+    cfg.table_name = "kv";
+    cfg.shard_key = "tenant_id+id";
+    cfg.shards = {ShardInfo{"s0"}, ShardInfo{"s1"}, ShardInfo{"s2"}};
+    ShardMap map;
+    map.add_table(cfg);
+
+    EXPECT_EQ(map.get_shard_keys(sref("kv")).size(), 2u);
+    EXPECT_EQ(std::string(map.get_shard_key(sref("kv")).ptr,
+                          map.get_shard_key(sref("kv")).len), "tenant_id");
+
+    ShardKeyPart a[] = {{true, 1, nullptr, 0}, {true, 3, nullptr, 0}};
+    ShardKeyPart b[] = {{true, 2, nullptr, 0}, {true, 3, nullptr, 0}};
+    size_t ia = 0, ib = 0, ia2 = 0;
+    ASSERT_TRUE(map.try_shard_index_for_parts(sref("kv"), a, 2, ia));
+    ASSERT_TRUE(map.try_shard_index_for_parts(sref("kv"), b, 2, ib));
+    ASSERT_TRUE(map.try_shard_index_for_parts(sref("kv"), a, 2, ia2));
+    EXPECT_EQ(ia, ia2);
+    EXPECT_LT(ia, 3u);
+    EXPECT_LT(ib, 3u);
 }

--- a/tests/test_shard_map.cpp
+++ b/tests/test_shard_map.cpp
@@ -278,3 +278,22 @@ TEST(ShardMapTest, CompositeHashIsDeterministicAndDiffersFromSingle) {
     EXPECT_LT(ia, 3u);
     EXPECT_LT(ib, 3u);
 }
+
+TEST(ShardMapTest, CompositeRangeRoutesOnFirstKey) {
+    TableShardConfig cfg;
+    cfg.table_name = "kv";
+    cfg.shard_key = "tenant_id+id";
+    cfg.shards = {ShardInfo{"s0"}, ShardInfo{"s1"}};
+    cfg.strategy = RoutingStrategy::RANGE;
+    cfg.ranges = {ShardRange{5, 0}, ShardRange{100, 1}};
+    ShardMap map;
+    map.add_table(cfg);
+
+    ShardKeyPart low[] = {{true, 3, nullptr, 0}, {true, 99, nullptr, 0}};
+    ShardKeyPart high[] = {{true, 9, nullptr, 0}, {true, 1, nullptr, 0}};
+    size_t il = 99, ih = 99;
+    ASSERT_TRUE(map.try_shard_index_for_parts(sref("kv"), low, 2, il));
+    ASSERT_TRUE(map.try_shard_index_for_parts(sref("kv"), high, 2, ih));
+    EXPECT_EQ(il, 0u);
+    EXPECT_EQ(ih, 1u);
+}

--- a/tests/test_shard_map.cpp
+++ b/tests/test_shard_map.cpp
@@ -9,6 +9,7 @@
 #include "sql_engine/shard_map.h"
 
 #include <set>
+#include <climits>
 
 using namespace sql_engine;
 using sql_parser::StringRef;
@@ -106,6 +107,23 @@ TEST(ShardMapRangeTest, MatchesDemoDataPlacement) {
     EXPECT_EQ(map.shard_index_for_int(sref("users"), 5), 0u);
     EXPECT_EQ(map.shard_index_for_int(sref("users"), 6), 1u);
     EXPECT_EQ(map.shard_index_for_int(sref("users"), 10), 1u);
+}
+
+TEST(ShardMapRangeTest, CollectIntRangeShards) {
+    TableShardConfig cfg = make_two_shards(RoutingStrategy::RANGE);
+    cfg.ranges = {ShardRange{5, 0}, ShardRange{10, 1}};
+    ShardMap map;
+    map.add_table(cfg);
+
+    std::vector<size_t> lo;
+    map.collect_int_range_shards(sref("users"), INT64_MIN, 5, lo);
+    ASSERT_EQ(lo.size(), 1u);
+    EXPECT_EQ(lo[0], 0u);
+
+    std::vector<size_t> hi;
+    map.collect_int_range_shards(sref("users"), 6, INT64_MAX, hi);
+    ASSERT_EQ(hi.size(), 1u);
+    EXPECT_EQ(hi[0], 1u);
 }
 
 TEST(ShardMapRangeTest, AboveMaxBoundFallsToLastShard) {

--- a/tests/test_ssl_config.cpp
+++ b/tests/test_ssl_config.cpp
@@ -237,8 +237,10 @@ TEST(SSLConfigTest, ParseShardSpecCompositeHash) {
     ASSERT_EQ(ps.config.shards.size(), 3u);
 }
 
-TEST(SSLConfigTest, ParseShardSpecRejectsCompositeRange) {
+TEST(SSLConfigTest, ParseShardSpecCompositeRangeUsesFirstKey) {
     auto ps = parse_shard_spec("kv:tenant_id+id:range:5=s0,10=s1");
-    EXPECT_FALSE(ps.ok);
-    EXPECT_NE(ps.error.find("HASH"), std::string::npos);
+    ASSERT_TRUE(ps.ok);
+    EXPECT_EQ(ps.config.strategy, RoutingStrategy::RANGE);
+    EXPECT_EQ(ps.config.shard_key, "tenant_id+id");
+    ASSERT_EQ(ps.config.ranges.size(), 2u);
 }

--- a/tests/test_ssl_config.cpp
+++ b/tests/test_ssl_config.cpp
@@ -226,3 +226,19 @@ TEST(SSLConfigTest, ParseShardSpecRejectsEmptyList) {
     EXPECT_FALSE(ps.ok);
     EXPECT_NE(ps.error.find("at least one"), std::string::npos);
 }
+
+TEST(SSLConfigTest, ParseShardSpecCompositeHash) {
+    auto ps = parse_shard_spec("kv:tenant_id+id:hash:s0,s1,s2");
+
+    ASSERT_TRUE(ps.ok);
+    EXPECT_EQ(ps.config.table_name, "kv");
+    EXPECT_EQ(ps.config.shard_key, "tenant_id+id");
+    EXPECT_EQ(ps.config.strategy, RoutingStrategy::HASH);
+    ASSERT_EQ(ps.config.shards.size(), 3u);
+}
+
+TEST(SSLConfigTest, ParseShardSpecRejectsCompositeRange) {
+    auto ps = parse_shard_spec("kv:tenant_id+id:range:5=s0,10=s1");
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("HASH"), std::string::npos);
+}

--- a/tools/engine_stress_test.cpp
+++ b/tools/engine_stress_test.cpp
@@ -35,6 +35,7 @@
 #include "sql_engine/in_memory_catalog.h"
 #include "sql_engine/data_source.h"
 #include "sql_engine/local_txn.h"
+#include "sql_engine/distributed_txn.h"
 #include "sql_engine/multi_remote_executor.h"
 #include "sql_engine/thread_safe_executor.h"
 #include "sql_engine/shard_map.h"
@@ -103,14 +104,13 @@ static void worker_thread(
     (void)thread_id;
 
     // Each thread gets its own arena, txn manager, executor, and session
-    Arena txn_arena{65536, 1048576};
-    LocalTransactionManager txn_mgr(txn_arena);
-
     ThreadSafeMultiRemoteExecutor remote_exec;
     for (auto& bc : backends) {
         remote_exec.add_backend(bc);
     }
 
+    DistributedTransactionManager txn_mgr(
+        remote_exec, DistributedTransactionManager::BackendDialect::MYSQL);
     Session<Dialect::MySQL> session(catalog, txn_mgr);
     session.set_remote_executor(&remote_exec);
     session.set_parallel_open(true);  // thread-safe executor enables parallel shard I/O

--- a/tools/engine_stress_test.cpp
+++ b/tools/engine_stress_test.cpp
@@ -377,11 +377,33 @@ static void discover_schemas(InMemoryCatalog& catalog,
 }
 
 // ============================================================
+static const std::string& backend_for_int_key(
+    const ShardMap& map,
+    const char* table,
+    int64_t key,
+    const std::vector<std::string>& fallback)
+{
+    StringRef t{table, static_cast<uint32_t>(std::strlen(table))};
+    if (!map.has_table(t) || map.get_shards(t).empty()) return fallback.front();
+    size_t idx = map.shard_index_for_int(t, key);
+    return map.get_shards(t)[idx].backend_name;
+}
+
+static int64_t load_key_for_table(const ShardMap& map, const char* table,
+                                   int64_t id, int64_t user_id) {
+    StringRef t{table, static_cast<uint32_t>(std::strlen(table))};
+    StringRef sk = map.get_shard_key(t);
+    if (sk.equals_ci("user_id", 7)) return user_id;
+    return id;
+}
+
 // Load test data via MySQL
 // ============================================================
 
 static void load_test_data(MultiRemoteExecutor& remote_exec,
                             const std::vector<TableShardConfig>& shards) {
+    ShardMap tmp_shards;
+    for (const auto& sc : shards) tmp_shards.add_table(sc);
     // Collect all unique backend names
     std::vector<std::string> all_backends;
     for (auto& sc : shards) {
@@ -450,7 +472,8 @@ static void load_test_data(MultiRemoteExecutor& remote_exec,
         std::string sql_str = sql.str();
         StringRef ref{sql_str.c_str(), static_cast<uint32_t>(sql_str.size())};
 
-        const std::string& bn = all_backends[static_cast<size_t>(i) % all_backends.size()];
+        const std::string& bn = backend_for_int_key(
+            tmp_shards, "users", load_key_for_table(tmp_shards, "users", i, i), all_backends);
         try { remote_exec.execute_dml(bn.c_str(), ref); } catch (...) {}
     }
 
@@ -466,7 +489,9 @@ static void load_test_data(MultiRemoteExecutor& remote_exec,
         std::string sql_str = sql.str();
         StringRef ref{sql_str.c_str(), static_cast<uint32_t>(sql_str.size())};
 
-        const std::string& bn = all_backends[static_cast<size_t>(i) % all_backends.size()];
+        const std::string& bn = backend_for_int_key(
+            tmp_shards, "orders",
+            load_key_for_table(tmp_shards, "orders", i, user_id), all_backends);
         try { remote_exec.execute_dml(bn.c_str(), ref); } catch (...) {}
     }
 

--- a/tools/mysql_server.cpp
+++ b/tools/mysql_server.cpp
@@ -49,6 +49,7 @@
 #include "sql_engine/in_memory_catalog.h"
 #include "sql_engine/data_source.h"
 #include "sql_engine/local_txn.h"
+#include "sql_engine/distributed_txn.h"
 #include "sql_engine/multi_remote_executor.h"
 #include "sql_engine/thread_safe_executor.h"
 #include "sql_engine/shard_map.h"
@@ -582,14 +583,13 @@ static void handle_connection(int client_fd, uint32_t conn_id, const ServerConte
     }
 
     // Set up per-connection session
-    Arena txn_arena{65536, 1048576};
-    LocalTransactionManager txn_mgr(txn_arena);
-
     ThreadSafeMultiRemoteExecutor remote_exec;
     for (auto& bc : ctx.backends) {
         remote_exec.add_backend(bc);
     }
 
+    DistributedTransactionManager txn_mgr(
+        remote_exec, DistributedTransactionManager::BackendDialect::MYSQL);
     Session<Dialect::MySQL> session(ctx.catalog, txn_mgr);
     session.set_remote_executor(&remote_exec);
     session.set_parallel_open(true);  // thread-safe executor enables parallel shard I/O

--- a/tools/sqlengine.cpp
+++ b/tools/sqlengine.cpp
@@ -356,8 +356,14 @@ int main(int argc, char* argv[]) {
     }
 
     if (remote_exec) {
+        bool all_pg = !backends.empty();
+        for (const auto& b : backends) {
+            if (b.dialect != Dialect::PostgreSQL) { all_pg = false; break; }
+        }
         dtxn.reset(new DistributedTransactionManager(
-            *remote_exec, DistributedTransactionManager::BackendDialect::MYSQL));
+            *remote_exec,
+            all_pg ? DistributedTransactionManager::BackendDialect::POSTGRESQL
+                   : DistributedTransactionManager::BackendDialect::MYSQL));
         if (!txn_log_path.empty()) {
             if (!txn_log.open(txn_log_path)) {
                 std::cerr << "Error: cannot open txn log " << txn_log_path << std::endl;

--- a/tools/sqlengine.cpp
+++ b/tools/sqlengine.cpp
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <iomanip>
 #include <unistd.h>
+#include <memory>
 
 #include "sql_parser/parser.h"
 #include "sql_parser/common.h"
@@ -25,6 +26,8 @@
 #include "sql_engine/in_memory_catalog.h"
 #include "sql_engine/data_source.h"
 #include "sql_engine/local_txn.h"
+#include "sql_engine/distributed_txn.h"
+#include "sql_engine/durable_txn_log.h"
 #include "sql_engine/multi_remote_executor.h"
 #include "sql_engine/thread_safe_executor.h"
 #include "sql_engine/shard_map.h"
@@ -226,6 +229,7 @@ static void print_usage(const char* prog) {
               << "Options:\n"
               << "  --backend URL    Add a backend (mysql://... or pgsql://...)\n"
               << "  --shard SPEC     Add shard config (table:key:shard1,shard2)\n"
+              << "  --txn-log PATH   Durable 2PC WAL (backend mode only)\n"
               << "  --help           Show this help\n"
               << "\n"
               << "In-memory mode (no --backend): evaluates expressions locally.\n"
@@ -239,6 +243,7 @@ static void print_usage(const char* prog) {
 int main(int argc, char* argv[]) {
     std::vector<BackendConfig> backends;
     std::vector<TableShardConfig> shards;
+    std::string txn_log_path;
 
     // Parse command-line args
     for (int i = 1; i < argc; ++i) {
@@ -254,6 +259,9 @@ int main(int argc, char* argv[]) {
                 return 1;
             }
             backends.push_back(std::move(pb.config));
+        } else if (arg == "--txn-log" && i + 1 < argc) {
+            ++i;
+            txn_log_path = argv[i];
         } else if (arg == "--shard" && i + 1 < argc) {
             ++i;
             auto ps = parse_shard_spec(argv[i]);
@@ -274,7 +282,10 @@ int main(int argc, char* argv[]) {
 
     // Set up arena for transaction manager
     Arena txn_arena{65536, 1048576};
-    LocalTransactionManager txn_mgr(txn_arena);
+    LocalTransactionManager local_txn(txn_arena);
+    std::unique_ptr<DistributedTransactionManager> dtxn;
+    DurableTransactionLog txn_log;
+    TransactionManager* txn_mgr = &local_txn;
 
     // Set up shard map
     ShardMap shard_map;
@@ -344,8 +355,20 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // Create session
-    Session<Dialect::MySQL> session(catalog, txn_mgr);
+    if (remote_exec) {
+        dtxn.reset(new DistributedTransactionManager(
+            *remote_exec, DistributedTransactionManager::BackendDialect::MYSQL));
+        if (!txn_log_path.empty()) {
+            if (!txn_log.open(txn_log_path)) {
+                std::cerr << "Error: cannot open txn log " << txn_log_path << std::endl;
+                return 1;
+            }
+            dtxn->set_durable_log(&txn_log);
+        }
+        txn_mgr = dtxn.get();
+    }
+
+    Session<Dialect::MySQL> session(catalog, *txn_mgr);
     if (remote_exec) {
         session.set_remote_executor(remote_exec);
         session.set_parallel_open(true);  // thread-safe executor enables parallel shard I/O


### PR DESCRIPTION
## Summary
- Route INSERT / UPDATE / DELETE / INSERT…SELECT through `ShardMap` (HASH / RANGE / LIST). SELECT prune already used `ShardMap`; DML had a private `abs(k)%n` / `h*31` hash, so `INSERT … VALUES (K)` then `SELECT … WHERE id = K` could hit different backends and return empty with no error.
- Fail closed when the shard key is missing, not a literal, or assigned in `UPDATE`.
- Reuse SELECT `prune_shards()` for targeted UPDATE/DELETE.
- Place `engine_stress_test --load-data` rows with `ShardMap`.
- Tests: INSERT-then-point-SELECT for HASH/RANGE/LIST, plus the three error cases.

## Validation
- `./run_tests --gtest_brief=1`: 1301 passed, 37 skipped (no live backends)
- `./run_tests --gtest_filter='DistributedDml*:ShardMap*:DistributedPlanner*'`
- `engine_stress_test` compiles

Based on current `main` (includes #50).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `DISTINCT` aggregate functions such as `COUNT(DISTINCT ...)`.
  - Improved `ORDER BY` support for positions, aliases, and expressions.
  - Added composite shard keys and enhanced range, list, hash, and join routing.
  - Added PostgreSQL connection pooling and distributed transaction support.
  - Added durable transaction logging to the SQL engine CLI.
  - Improved distributed execution for windows, derived queries, aggregates, joins, and multi-source `UNION ALL`.

- **Bug Fixes**
  - Improved `HAVING` behavior and aggregate filtering.
  - Preserved longer remote SQL statements without truncation.
  - Prevented invalid or unsafe shard-key operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->